### PR TITLE
add: HTML解析ロジックの実装

### DIFF
--- a/saba/saba_core/src/browser.rs
+++ b/saba/saba_core/src/browser.rs
@@ -1,0 +1,57 @@
+//! ブラウザ本体（Browser）— 複数ページの管理と“現在のページ”の取得
+//!
+//! 役割（実ブラウザのどの部分？）
+//! - タブ/ウィンドウの管理に相当します。ここでは最小構成として「複数ページ(Page)配列」と
+//!   「アクティブなページのインデックス」だけを持ちます。
+//! - `Page` が DOM 構築やレンダリングの具体を担当し、`Browser` は切替や生成を司るイメージです。
+//!
+//! 言語ブリッジ（TS / Python / Go）
+//! - `Rc<RefCell<T>>` は“共有 + 内部可変”。複数箇所から同じ `Page` を参照し、必要時に書き換えます。
+//!   - TS/Python/Go だと普通の参照共有に近い感覚ですが、Rust では所有権のために包む必要があります。
+//! - `Weak<...>` を使うと循環参照を避けられます（`Page` → `Browser` の逆参照など）。
+//!
+//! 使い方（最小例）
+//! ```ignore
+//! let browser = Browser::new();
+//! let page = browser.borrow().current_page();
+//! // page.borrow_mut().navigate("http://...") のようなAPIを増やしていく想定
+//! ```
+
+use crate::renderer::page::Page;
+use alloc::rc::Rc;
+use alloc::vec::Vec;
+use core::cell::RefCell;
+
+#[derive(Debug, Clone)]
+pub struct Browser {
+    active_page_index: usize,
+    pages: Vec<Rc<RefCell<Page>>>,
+}
+
+impl Browser {
+    // 新しいブラウザを作成し、空の Page を1枚だけ持った状態で返します。
+    // 返り値を Rc<RefCell<Self>> にしているのは、アプリのあちこちから共有し、
+    // 必要に応じて内部を書き換えたい（内部可変にしたい）ためです。
+    pub fn new() -> Rc<RefCell<Self>> {
+        let mut page = Page::new();
+
+        let browser = Rc::new(RefCell::new(Self {
+            active_page_index: 0,
+            pages: Vec::new(),
+        }));
+
+        // Page から Browser への逆参照（弱参照）を張ることで、
+        // 循環参照（強参照サイクル）にならないようにしています。
+        page.set_browser(Rc::downgrade(&browser));
+        // 最初のページをブラウザに登録。
+        browser.borrow_mut().pages.push(Rc::new(RefCell::new(page)));
+
+        browser
+    }
+
+    // 現在アクティブなページ（タブ）を取得します。
+    // ここでは単一タブ運用のため常に index=0 を返しますが、将来はタブ切替で変動します。
+    pub fn current_page(&self) -> Rc<RefCell<Page>> {
+        self.pages[self.active_page_index].clone()
+    }
+}

--- a/saba/saba_core/src/lib.rs
+++ b/saba/saba_core/src/lib.rs
@@ -42,4 +42,5 @@ extern crate alloc; // no_std でも `String`/`Vec` を使うために必要
 
 pub mod error; // 共有エラー型（Result<T, Error> 用）
 pub mod http; // HTTP の型/処理（I/Oは含まない）
+pub mod renderer; // HTMLレンダリング
 pub mod url; // URL ユーティリティ

--- a/saba/saba_core/src/lib.rs
+++ b/saba/saba_core/src/lib.rs
@@ -40,7 +40,9 @@
 
 extern crate alloc; // no_std でも `String`/`Vec` を使うために必要
 
+pub mod browser;
 pub mod error; // 共有エラー型（Result<T, Error> 用）
 pub mod http; // HTTP の型/処理（I/Oは含まない）
 pub mod renderer; // HTMLレンダリング
-pub mod url; // URL ユーティリティ
+pub mod url;
+pub mod utils; // URL ユーティリティ

--- a/saba/saba_core/src/renderer/dom/mod.rs
+++ b/saba/saba_core/src/renderer/dom/mod.rs
@@ -1,0 +1,1 @@
+pub mod node;

--- a/saba/saba_core/src/renderer/dom/node.rs
+++ b/saba/saba_core/src/renderer/dom/node.rs
@@ -1,0 +1,252 @@
+//! DOM ノード（Window/Document/Element/Text）の最小実装（初心者向け）
+//!
+//! これは“ブラウザの内部表現（DOM: Document Object Model）”のごく小さなモデルです。
+//! - 実際のブラウザでは、HTML をパースすると「ノードの木構造（DOM ツリー）」が作られます。
+//! - このファイルでは、その最小構成として `Window`（最上位のグローバル）→`Document`→
+//!   `Element`/`Text` という階層を `Node` で表現しています。
+//! - 兄弟/親子リンクを持つ「双方向の木」を、Rust の `Rc<RefCell<...>>` と `Weak` を使って実現します。
+//!
+//! 言語ブリッジ（TS / Python / Go）
+//! - `Rc<T>` は参照カウント付きの“共有所有権”。TS/Python/Go では普通の参照共有に近い感覚。
+//! - `RefCell<T>` は“内部可変”。借用ルールをランタイムチェックに委ね、中身を変更可能にします。
+//! - `Weak<T>` は循環参照を避けるための「弱い参照」。親や前後のリンクに使い、`Rc` サイクルを防ぎます。
+//! - DOM 用語の対応: Node ≈ DOM Node, Element ≈ HTMLElement, Text ≈ TextNode, Window/Document はブラウザのグローバル/文書。
+//!
+//! 例（簡単なツリー: <p>Hello</p>）
+//! ```ignore
+//! let win = Window::new();                 // Window → Document（空）
+//! let doc = win.document();                // Rc<RefCell<Node>>
+//! // ここでパーサが作る想定: Document の下に Element(p) と Text("Hello") をぶら下げる …
+//! // 本ファイルは木の型・リンクを提供し、パース・レンダリング層がこの構造を操作します。
+//! ```
+//! ブラウザ挙動での役割
+//! - パース後: DOM ツリー（この Node 構造体群）が完成。
+//! - レイアウト/描画: この DOM ツリーをもとにフレームツリー/レイアウトツリーを作成し描画（ここでは未実装）。
+//! - イベント/スクリプト: Window/Document を起点にイベント配信や JS 実行（ここでは最小限）。
+
+use crate::renderer::html::attribute::Attribute;
+use alloc::format;
+use alloc::rc::Rc;
+use alloc::rc::Weak;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::cell::RefCell;
+use core::str::FromStr;
+
+#[derive(Debug, Clone)]
+pub struct Window {
+    document: Rc<RefCell<Node>>,
+}
+
+impl Window {
+    // ブラウザの `window` に相当。作成時に空の `Document` ノードを用意します。
+    // 注意: `Rc`/`Weak` で自己参照関係を張るため、生成ステップが少し回りくどいです。
+    pub fn new() -> Self {
+        let window = Self {
+            document: Rc::new(RefCell::new(Node::new(NodeKind::Document))),
+        };
+
+        window
+            .document
+            .borrow_mut()
+            .set_window(Rc::downgrade(&Rc::new(RefCell::new(window.clone()))));
+
+        window
+    }
+
+    // 実ブラウザ API の `window.document` に相当。
+    pub fn document(&self) -> Rc<RefCell<Node>> {
+        self.document.clone()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Node {
+    pub kind: NodeKind,
+    window: Weak<RefCell<Window>>,
+    parent: Weak<RefCell<Node>>,
+    first_child: Option<Rc<RefCell<Node>>>,
+    last_child: Weak<RefCell<Node>>,
+    previous_sibling: Weak<RefCell<Node>>,
+    next_sibling: Option<Rc<RefCell<Node>>>,
+}
+
+impl PartialEq for Node {
+    fn eq(&self, other: &Self) -> bool {
+        self.kind == other.kind
+    }
+}
+
+impl Node {
+    // ノードを新規に作成。リンク（親/兄弟/子）は空で、種別だけを持ちます。
+    pub fn new(kind: NodeKind) -> Self {
+        Self {
+            kind,
+            window: Weak::new(),
+            parent: Weak::new(),
+            first_child: None,
+            last_child: Weak::new(),
+            previous_sibling: Weak::new(),
+            next_sibling: None,
+        }
+    }
+
+    // Window 弱参照をセット。`Window::new` 時に Document 側へ逆リンクとして張ります。
+    pub fn set_window(&mut self, window: Weak<RefCell<Window>>) {
+        self.window = window;
+    }
+
+    // 親ノードを Weak でセット。循環参照（リーク）を避けるため Rc ではなく Weak。
+    pub fn set_parent(&mut self, parent: Weak<RefCell<Node>>) {
+        self.parent = parent;
+    }
+
+    // 親ノード取得（Weak）。必要に応じて `upgrade()` して Rc に変換します。
+    pub fn parent(&self) -> Weak<RefCell<Node>> {
+        self.parent.clone()
+    }
+
+    // 最初の子への Rc をセット/取得。
+    pub fn set_first_child(&mut self, first_child: Option<Rc<RefCell<Node>>>) {
+        self.first_child = first_child;
+    }
+
+    pub fn first_child(&self) -> Option<Rc<RefCell<Node>>> {
+        self.first_child.as_ref().cloned()
+    }
+
+    // 最後の子への Weak をセット/取得。Rc にしたいときは `upgrade()` を使います。
+    pub fn set_last_child(&mut self, last_child: Weak<RefCell<Node>>) {
+        self.last_child = last_child;
+    }
+
+    pub fn last_child(&self) -> Weak<RefCell<Node>> {
+        self.last_child.clone()
+    }
+
+    // 兄（直前の兄弟）/弟（直後の兄弟）のリンクをセット/取得。
+    pub fn set_previous_sibling(&mut self, previous_sibling: Weak<RefCell<Node>>) {
+        self.previous_sibling = previous_sibling;
+    }
+
+    pub fn previous_sibling(&self) -> Weak<RefCell<Node>> {
+        self.previous_sibling.clone()
+    }
+
+    pub fn set_next_sibling(&mut self, next_sibling: Option<Rc<RefCell<Node>>>) {
+        self.next_sibling = next_sibling;
+    }
+
+    pub fn next_sibling(&self) -> Option<Rc<RefCell<Node>>> {
+        self.next_sibling.as_ref().cloned()
+    }
+
+    // ノード種別（Document / Element / Text）を取得。
+    pub fn kind(&self) -> NodeKind {
+        self.kind.clone()
+    }
+
+    // Element ノードなら要素情報を返す（タグ名や属性群）。Text/Document なら None。
+    pub fn get_element(&self) -> Option<Element> {
+        match self.kind {
+            NodeKind::Document | NodeKind::Text(_) => None,
+            NodeKind::Element(ref e) => Some(e.clone()),
+        }
+    }
+
+    // Element ノードなら要素の種類（p/h1/body など）を返す。Text/Document なら None。
+    pub fn element_kind(&self) -> Option<ElementKind> {
+        match self.kind {
+            NodeKind::Document | NodeKind::Text(_) => None,
+            NodeKind::Element(ref e) => Some(e.kind()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq)]
+pub enum NodeKind {
+    /// https://dom.spec.whatwg.org/#interface-document
+    Document,
+    /// https://dom.spec.whatwg.org/#interface-element
+    Element(Element),
+    /// https://dom.spec.whatwg.org/#interface-text
+    Text(String),
+}
+
+impl PartialEq for NodeKind {
+    fn eq(&self, other: &Self) -> bool {
+        match &self {
+            NodeKind::Document => matches!(other, NodeKind::Document),
+            NodeKind::Element(e1) => match &other {
+                NodeKind::Element(e2) => e1.kind == e2.kind,
+                _ => false,
+            },
+            NodeKind::Text(_) => matches!(other, NodeKind::Text(_)),
+        }
+    }
+}
+
+/// https://dom.spec.whatwg.org/#interface-element
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Element {
+    kind: ElementKind,
+    attributes: Vec<Attribute>,
+}
+
+impl Element {
+    // 文字列のタグ名（"p", "h1" など）と属性リストから Element を生成。
+    // 実ブラウザでは不正なタグ名も許容されますが、ここでは列挙型に無いとエラーにします。
+    pub fn new(element_name: &str, attributes: Vec<Attribute>) -> Self {
+        Self {
+            kind: ElementKind::from_str(element_name)
+                .expect("failed to convert string to ElementKind"),
+            attributes,
+        }
+    }
+
+    // 要素の種類（ElementKind）を返す（タグ名に相当）。
+    pub fn kind(&self) -> ElementKind {
+        self.kind
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+/// https://dom.spec.whatwg.org/#interface-element
+pub enum ElementKind {
+    /// https://html.spec.whatwg.org/multipage/semantics.html#the-html-element
+    Html,
+    /// https://html.spec.whatwg.org/multipage/semantics.html#the-head-element
+    Head,
+    /// https://html.spec.whatwg.org/multipage/semantics.html#the-style-element
+    Style,
+    /// https://html.spec.whatwg.org/multipage/scripting.html#the-script-element
+    Script,
+    /// https://html.spec.whatwg.org/multipage/sections.html#the-body-element
+    Body,
+    /// https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element
+    P,
+    /// https://html.spec.whatwg.org/multipage/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements
+    H1,
+    H2,
+    /// https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element
+    A,
+}
+
+impl FromStr for ElementKind {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "html" => Ok(ElementKind::Html),
+            "head" => Ok(ElementKind::Head),
+            "style" => Ok(ElementKind::Style),
+            "script" => Ok(ElementKind::Script),
+            "body" => Ok(ElementKind::Body),
+            "p" => Ok(ElementKind::P),
+            "h1" => Ok(ElementKind::H1),
+            "h2" => Ok(ElementKind::H2),
+            "a" => Ok(ElementKind::A),
+            _ => Err(format!("unimplemented element name {:?}", s)),
+        }
+    }
+}

--- a/saba/saba_core/src/renderer/html/attribute.rs
+++ b/saba/saba_core/src/renderer/html/attribute.rs
@@ -1,0 +1,60 @@
+//! HTML 属性（attribute）の最小表現とユーティリティ
+//!
+//! 目的（概要）
+//! - HTML の `name="value"` のペアを表すシンプルな構造体です。
+//! - パーサーが1文字ずつ読み進める想定で、`add_char` で名前／値に文字を追加できます。
+//!
+//! 用語の橋渡し（TS / Python / Go）
+//! - `String` は“所有する文字列”。TS の `string`、Python の `str`、Go の `string` に相当。
+//! - `push(c)` は末尾に1文字追加。TS: `s += c`、Python: `s += c`（実際は新規作成）、Go: `s += string(c)`。
+//! - `clone()` は“複製を返す”。所有権を保ったまま呼び出し側に値を渡すときに便利です。
+//!
+//! 使い方（イメージ）
+//! ```ignore
+//! use saba_core::renderer::html::attribute::Attribute;
+//!
+//! // name="value" を1文字ずつ作る
+//! let mut attr = Attribute::new();
+//! for ch in "class".chars() { attr.add_char(ch, true); }     // name 部分
+//! for ch in "button primary".chars() { attr.add_char(ch, false); } // value 部分
+//! assert_eq!(attr.name(), "class".to_string());
+//! assert_eq!(attr.value(), "button primary".to_string());
+//! ```
+
+use alloc::string::String;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Attribute {
+    name: String,  // 例: "class"
+    value: String, // 例: "button primary"
+}
+
+impl Attribute {
+    // いわゆる“コンストラクタ”。空の name/value で開始します。
+    pub fn new() -> Self {
+        Self {
+            name: String::new(),
+            value: String::new(),
+        }
+    }
+
+    // 1文字を追加する。`is_name=true` なら name 側、false なら value 側へ。
+    // パーサーがトークンを読んでいる途中に少しずつ構築するユースケースを想定しています。
+    pub fn add_char(&mut self, c: char, is_name: bool) {
+        if is_name {
+            self.name.push(c);
+        } else {
+            self.value.push(c)
+        }
+    }
+
+    // 所有権を保ったまま取得できるよう、複製（clone）を返します。
+    pub fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    // 同上。必要に応じて `&str` を返す API にすると余分なコピーを避けられます。
+    pub fn value(&self) -> String {
+        self.value.clone()
+    }
+}

--- a/saba/saba_core/src/renderer/html/mod.rs
+++ b/saba/saba_core/src/renderer/html/mod.rs
@@ -1,0 +1,2 @@
+pub mod attribute;
+pub mod token;

--- a/saba/saba_core/src/renderer/html/mod.rs
+++ b/saba/saba_core/src/renderer/html/mod.rs
@@ -1,2 +1,3 @@
 pub mod attribute;
 pub mod token;
+pub mod parser;

--- a/saba/saba_core/src/renderer/html/parser.rs
+++ b/saba/saba_core/src/renderer/html/parser.rs
@@ -1,0 +1,840 @@
+use crate::renderer::dom::node::Element;
+use crate::renderer::dom::node::ElementKind;
+use crate::renderer::dom::node::Node;
+use crate::renderer::dom::node::NodeKind;
+use crate::renderer::dom::node::Window;
+use crate::renderer::html::attribute::Attribute;
+use crate::renderer::html::token::HtmlToken;
+use crate::renderer::html::token::HtmlTokenizer;
+use alloc::rc::Rc;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::cell::RefCell;
+use core::str::FromStr;
+
+/// https://html.spec.whatwg.org/multipage/parsing.html#the-insertion-mode
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum InsertionMode {
+    Initial,
+    BeforeHtml,
+    BeforeHead,
+    InHead,
+    AfterHead,
+    InBody,
+    Text,
+    AfterBody,
+    AfterAfterBody,
+}
+
+#[derive(Debug, Clone)]
+pub struct HtmlParser {
+    window: Rc<RefCell<Window>>,
+    mode: InsertionMode,
+    /// https://html.spec.whatwg.org/multipage/parsing.html#original-insertion-mode
+    original_insertion_mode: InsertionMode,
+    /// https://html.spec.whatwg.org/multipage/parsing.html#the-stack-of-open-elements
+    stack_of_open_elements: Vec<Rc<RefCell<Node>>>, // ブラウザが使用するスタック(final-in-last-out)
+    t: HtmlTokenizer,
+}
+
+impl HtmlParser {
+    pub fn new(t: HtmlTokenizer) -> Self {
+        Self {
+            window: Rc::new(RefCell::new(Window::new())),
+            mode: InsertionMode::Initial,
+            original_insertion_mode: InsertionMode::Initial,
+            stack_of_open_elements: Vec::new(),
+            t,
+        }
+    }
+
+    // stack_of_open_elementsスタックに存在する全ての要素を確認し、特定の種類がある場合にtrueを返す
+    fn contain_in_stack(&mut self, element_kind: ElementKind) -> bool {
+        for i in 0..self.stack_of_open_elements.len() {
+            if self.stack_of_open_elements[i].borrow().element_kind() == Some(element_kind) {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    // stack_of_open_elementsスタックから特定の種類の要素が現れるまでノードを取り出し続ける
+    fn pop_until(&mut self, element_kind: ElementKind) {
+        assert!(
+            self.contain_in_stack(element_kind),
+            "stack doesn't have an element {:?}",
+            element_kind,
+        );
+
+        loop {
+            let current = match self.stack_of_open_elements.pop() {
+                Some(n) => n,
+                None => return,
+            };
+
+            if current.borrow().element_kind() == Some(element_kind) {
+                return;
+            }
+        }
+    }
+
+    // stack_of_open_elementsスタックから1つのノードを取り出し、そのノードが特定の種類と一致する場合にtrueを返す。異なる種類の場合はfalseを返す。
+    fn pop_current_node(&mut self, element_kind: ElementKind) -> bool {
+        let current = match self.stack_of_open_elements.last() {
+            Some(n) => n,
+            None => return false,
+        };
+
+        if current.borrow().element_kind() == Some(element_kind) {
+            self.stack_of_open_elements.pop();
+            return true;
+        }
+
+        false
+    }
+
+    fn create_char(&self, c: char) -> Node {
+        let mut s = String::new();
+        s.push(c);
+        Node::new(NodeKind::Text(s))
+    }
+
+    /// 文字トークンを DOM に反映する（テキストノードの生成/追記）
+    ///
+    /// 実ブラウザにおける挙動に対応
+    /// - HTML パーサは「テキストノードの連結（coalescing）」を行い、
+    ///   連続する文字は同じ Text ノードへまとめます。
+    /// - 空白や改行の扱いは挿入モードや要素種別で変わりますが、ここでは最小仕様として
+    ///   改行/スペースはスキップしています（簡易ホワイトスペース抑制）。
+    ///
+    /// 実装の要点
+    /// - `stack_of_open_elements` の末尾（現在の挿入先）に対して処理します。
+    /// - すでに直近が `Text` ならその文字列へ `push`（coalescing）。
+    /// - そうでなければ新しい `Text` ノードを作って親子/兄弟リンクを張ります。
+    fn insert_char(&mut self, c: char) {
+        let current = match self.stack_of_open_elements.last() {
+            Some(n) => n.clone(),
+            None => return,
+        };
+
+        // 1) 直近ノードが Text なら、そこへ追記（テキストの連結）。
+        //    実ブラウザも「連続する文字トークンは同一の Text ノードにまとめる」動きをします。
+        if let NodeKind::Text(ref mut s) = current.borrow_mut().kind {
+            s.push(c);
+            return;
+        }
+
+        // 2) 簡易ホワイトスペース制御: 改行/スペースはスキップ。
+        //    （本来はインサーションモードや CSS の空白折り畳み規則に依存。最小実装として抑制。）
+        if c == '\n' || c == ' ' {
+            return;
+        }
+
+        // 3) それ以外の文字は、新しい Text ノードを生成。
+        let node = Rc::new(RefCell::new(self.create_char(c)));
+
+        // 4) 親（current）に子がすでに居る場合は、先頭子の `next_sibling` にぶら下げる。
+        //    NOTE: 一般的には「最後の子の next_sibling に追加」するのが自然ですが、
+        //    ここでは簡略化のため first_child の next として接続しています。
+        //    将来的に正確な木構造を保つなら、最後の子を辿って末尾に繋ぐのが安全です（TODO候補）。
+        if current.borrow().first_child().is_some() {
+            current
+                .borrow()
+                .first_child()
+                .unwrap()
+                .borrow_mut()
+                .set_next_sibling(Some(node.clone()));
+        } else {
+            // 親に子がいなければ最初の子として登録。
+            current.borrow_mut().set_first_child(Some(node.clone()));
+        }
+
+        // 5) 親の last_child を更新し、子から親への逆リンク（parent）を設定。
+        current.borrow_mut().set_last_child(Rc::downgrade(&node));
+        node.borrow_mut().set_parent(Rc::downgrade(&current));
+
+        // 6) “現在の挿入位置”をこの Text ノードへ更新。
+        //    以降の連続する文字は上の 1) の分岐で同一ノードへ連結されます。
+        self.stack_of_open_elements.push(node);
+    }
+
+    fn create_element(&self, tag: &str, attributes: Vec<Attribute>) -> Node {
+        Node::new(NodeKind::Element(Element::new(tag, attributes)))
+    }
+
+    /// 開始タグを DOM に挿入する（要素ノードの生成と親子/兄弟リンクの更新）
+    ///
+    /// 実ブラウザでいう「ツリービルダー」の仕事に相当します。
+    /// - 直近の挿入先（stack_of_open_elements の末尾、なければ Document）に、
+    ///   新しい Element ノードを子として追加します。
+    /// - 兄弟がいる場合は、最後の子の直後に連結します（末尾へ追加）。
+    /// - 追加後、その要素を“現在開いている要素”としてスタックに push します。
+    fn insert_element(&mut self, tag: &str, attributes: Vec<Attribute>) {
+        let window = self.window.borrow();
+        // 1) 挿入先（カレントノード）を決める
+        let current = match self.stack_of_open_elements.last() {
+            // 現在開いている要素スタックの最後のノードを取得
+            Some(n) => n.clone(),
+            None => window.document(), // スタックが空なら Document 直下に挿入
+        };
+
+        // 2) 新しい要素ノードを作成（タグ名と属性を保持）
+        //    Rc<RefCell<_>> に包むことで“共有 + 内部可変”にします（DOM 編集がしやすい）。
+        let node = Rc::new(RefCell::new(self.create_element(tag, attributes)));
+
+        // 3) 末尾に追加するため、最後の子（last_sibling）を探す
+        if current.borrow().first_child().is_some() {
+            // すでに子要素がある場合は、先頭から next_sibling を辿って末尾へ
+            let mut last_sibling = current.borrow().first_child();
+            loop {
+                last_sibling = match last_sibling {
+                    Some(ref node) => {
+                        if node.borrow().next_sibling().is_some() {
+                            node.borrow().next_sibling()
+                        } else {
+                            break;
+                        }
+                    }
+                    None => unimplemented!("last_sibling should be Some"),
+                };
+            }
+
+            // 4) 末尾の兄弟の next_sibling と、新ノードの previous_sibling を接続
+            last_sibling
+                .as_ref()
+                .unwrap()
+                .borrow_mut()
+                .set_next_sibling(Some(node.clone())); // 兄弟ノードの直後に追加
+            node.borrow_mut().set_previous_sibling(Rc::downgrade(
+                &last_sibling.expect("last_sibling should be Some"),
+            ))
+        } else {
+            // 兄弟ノードが存在しない場合（= 子がまだいない）
+            current.borrow_mut().set_first_child(Some(node.clone())); // 最初の子として登録
+        }
+
+        // 5) 親子リンクの仕上げ（last_child と parent）
+        current.borrow_mut().set_last_child(Rc::downgrade(&node)); // 親の最後の子を更新
+        node.borrow_mut().set_parent(Rc::downgrade(&current)); // 子から親への逆リンク
+
+        // 6) ツリービルダーの規則: 開始タグを見たら、その要素を「開いている要素スタック」に積む
+        self.stack_of_open_elements.push(node);
+    }
+
+    /// HTML トークン列から DOM ツリーを組み立てる（ツリービルダーの簡易実装）
+    ///
+    /// 実ブラウザとの対応
+    /// - HTML パーサは「トークナイザ（字句解析）」と「ツリービルダー（構文解析）」の二段構えです。
+    /// - ここでは `HtmlTokenizer` が1トークンずつ供給し、`InsertionMode`（挿入モード）に応じて
+    ///   DOM ノード（Element/Text）を追加・スタック操作します。
+    /// - 省略可能な要素（html/head/body）は、仕様に倣い必要に応じて自動挿入します。
+    pub fn construct_tree(&mut self) -> Rc<RefCell<Window>> {
+        // トークナイザから最初のトークンを受け取る。
+        let mut token = self.t.next();
+
+        // トークンが存在する間、現在の挿入モードに従って処理を進める。
+        while token.is_some() {
+            match self.mode {
+                InsertionMode::Initial => {
+                    // 初期モード: この実装では DOCTYPE をサポートしない。
+                    // そのため "<!doctype html>" のような入力は Char として届くが、ここでは捨てる。
+                    if let Some(HtmlToken::Char(_)) = token {
+                        token = self.t.next();
+                        continue;
+                    }
+
+                    // DOCTYPE を読み飛ばしたら BeforeHtml へ遷移。
+                    self.mode = InsertionMode::BeforeHtml;
+                    continue;
+                }
+                InsertionMode::BeforeHtml => {
+                    // html 要素の直前段階。先頭の空白は無視し、<html> を待つ。
+                    match token {
+                        Some(HtmlToken::Char(c)) => {
+                            // 次のトークンが空白文字や改行文字の時
+                            if c == ' ' || c == '\n' {
+                                token = self.t.next();
+                                continue;
+                            }
+                        }
+                        Some(HtmlToken::StartTag {
+                            ref tag,
+                            self_closing: _,
+                            ref attributes,
+                        }) => {
+                            if tag == "html" {
+                                // <html> を受け取ったので、要素を挿入して BeforeHead へ。
+                                self.insert_element(tag, attributes.to_vec());
+                                self.mode = InsertionMode::BeforeHead;
+                                token = self.t.next();
+                                continue;
+                            }
+                        }
+                        Some(HtmlToken::EndTag { ref tag }) => {
+                            // 想定外の終了タグは無視（仕様にあるエラー回復のごく一部）。
+                            if tag != "head" || tag != "body" || tag != "html" || tag != "br" {
+                                token = self.t.next();
+                                continue;
+                            }
+                        }
+                        Some(HtmlToken::Eof) | None => {
+                            // 入力が空のときは空の Document を返す。
+                            return self.window.clone();
+                        }
+                    }
+                    // ここまで来たら <html> が省略されているとみなし、自動挿入する。
+                    self.insert_element("html", Vec::new());
+                    self.mode = InsertionMode::BeforeHead;
+                    continue;
+                }
+                InsertionMode::BeforeHead => {
+                    // <head> の直前。空白は無視し、<head> を待つ。
+                    match token {
+                        Some(HtmlToken::Char(c)) => {
+                            if c == ' ' || c == '\n' {
+                                // 次のトークンが空白文字や改行文字の時
+                                token = self.t.next();
+                                continue;
+                            }
+                        }
+                        Some(HtmlToken::StartTag {
+                            ref tag,
+                            self_closing: _,
+                            ref attributes,
+                        }) => {
+                            if tag == "head" {
+                                // <head> を受け取ったので挿入し、InHead へ。
+                                self.insert_element(tag, attributes.to_vec());
+                                self.mode = InsertionMode::InHead;
+                                token = self.t.next();
+                                continue;
+                            }
+                        }
+                        Some(HtmlToken::Eof) | None => {
+                            // 早期終端: 現在の Document を返す。
+                            return self.window.clone();
+                        }
+                        _ => {}
+                    }
+                    // <head> が省略されたとみなし、自動挿入（仕様でも許容）。
+                    self.insert_element("head", Vec::new());
+                    self.mode = InsertionMode::InHead;
+                    continue;
+                }
+
+                // 主にheadの終了タグ、style開始タグ、script開始タグを取り扱う
+                InsertionMode::InHead => {
+                    // <head> 内の処理。style/script はテキストモードへ遷移。
+                    match token {
+                        Some(HtmlToken::Char(c)) => {
+                            // 次のトークンが空白文字や改行文字の時
+                            if c == ' ' || c == '\n' {
+                                self.insert_char(c);
+                                token = self.t.next();
+                                continue;
+                            }
+                        }
+                        Some(HtmlToken::StartTag {
+                            ref tag,
+                            self_closing: _,
+                            ref attributes,
+                        }) => {
+                            if tag == "style" || tag == "script" {
+                                // StartTagかつタグの名前がstyleまたはscriptだった時
+                                self.insert_element(tag, attributes.to_vec());
+                                self.original_insertion_mode = self.mode;
+                                self.mode = InsertionMode::Text;
+                                token = self.t.next();
+                                continue;
+                            }
+                            // 仕様書には定められていないが、このブラウザは仕様を全て実装している
+                            // わけではないので、<head>が省略されているHTML文書を扱うために必要。
+                            // これがないと<head>が省略されているHTML文書で無限ループが発生
+                            if tag == "body" {
+                                self.pop_until(ElementKind::Head);
+                                self.mode = InsertionMode::AfterHead;
+                                continue;
+                            }
+                            if let Ok(_element_kind) = ElementKind::from_str(tag) {
+                                // <meta> など未対応タグが来た時の簡易的な抜け道として AfterHead へ。
+                                self.pop_until(ElementKind::Head);
+                                self.mode = InsertionMode::AfterHead;
+                                continue;
+                            }
+                        }
+                        Some(HtmlToken::EndTag { ref tag }) => {
+                            // EndTag かつ名前が head のとき
+                            if tag == "head" {
+                                self.mode = InsertionMode::AfterHead;
+                                token = self.t.next();
+                                self.pop_until(ElementKind::Head);
+                                continue;
+                            }
+                        }
+                        Some(HtmlToken::Eof) | None => {
+                            // 入力終端: ここまでの Document を返す。
+                            return self.window.clone();
+                        }
+                    }
+                    // <meta>や<title>などのサポートしていないタグは無視する
+                    token = self.t.next();
+                    continue;
+                }
+
+                // body開始タグを扱う
+                InsertionMode::AfterHead => {
+                    // <head> の後。<body> を待ち、来なければ自動挿入。
+                    match token {
+                        Some(HtmlToken::Char(c)) => {
+                            // 空白や改行の時
+                            if c == ' ' || c == '\n' {
+                                self.insert_char(c);
+                                token = self.t.next();
+                                continue;
+                            }
+                        }
+                        Some(HtmlToken::StartTag {
+                            ref tag,
+                            self_closing: _,
+                            ref attributes,
+                        }) => {
+                            if tag == "body" {
+                                // 次のタグがStartTagでかつタグ名がbodyのとき
+                                self.insert_element(tag, attributes.to_vec());
+                                token = self.t.next();
+                                self.mode = InsertionMode::InBody;
+                                continue;
+                            }
+                        }
+                        Some(HtmlToken::Eof) | None => {
+                            return self.window.clone();
+                        }
+                        _ => {}
+                    }
+                    // ここまで来たら <body> を省略とみなし、自動挿入。
+                    self.insert_element("body", Vec::new());
+                    self.mode = InsertionMode::InBody;
+                    continue;
+                }
+
+                // HTMLのbodyタグのコンテンツを扱う
+                // div, h1, pタグなどのことを指す
+                InsertionMode::InBody => {
+                    // 本文の主要要素を処理。開始タグは要素を挿入、終了タグはスタックを畳む。
+                    match token {
+                        Some(HtmlToken::StartTag {
+                            ref tag,
+                            self_closing: _,
+                            ref attributes,
+                        }) => match tag.as_str() {
+                            "p" => {
+                                self.insert_element(tag, attributes.to_vec());
+                                token = self.t.next();
+                                continue;
+                            }
+                            "h1" | "h2" => {
+                                self.insert_element(tag, attributes.to_vec());
+                                token = self.t.next();
+                                continue;
+                            }
+                            "a" => {
+                                self.insert_element(tag, attributes.to_vec());
+                                token = self.t.next();
+                                continue;
+                            }
+                            _ => {
+                                token = self.t.next();
+                            }
+                        },
+                        Some(HtmlToken::EndTag { ref tag }) => {
+                            match tag.as_str() {
+                                "body" => {
+                                    // </body> で AfterBody へ遷移し、BODY が開いていれば畳む。
+                                    self.mode = InsertionMode::AfterBody;
+                                    token = self.t.next();
+                                    if !self.contain_in_stack(ElementKind::Body) {
+                                        // パースの失敗。トークンを無視する
+                                        continue;
+                                    }
+                                    self.pop_until(ElementKind::Body);
+                                    continue;
+                                }
+                                "html" => {
+                                    // </html> の簡易処理。BODY が直前に閉じていれば AfterBody。
+                                    if self.pop_current_node(ElementKind::Body) {
+                                        self.mode = InsertionMode::AfterBody;
+                                        assert!(self.pop_current_node(ElementKind::Html));
+                                    } else {
+                                        token = self.t.next();
+                                    }
+                                    continue;
+                                }
+                                "p" => {
+                                    // </p> 等の特定要素は、その要素が現れるまでスタックを巻き戻す。
+                                    let element_kind = ElementKind::from_str(tag)
+                                        .expect("failed to convert string to ElementKind");
+                                    token = self.t.next();
+                                    self.pop_until(element_kind);
+                                    continue;
+                                }
+                                "h1" | "h2" => {
+                                    let element_kind = ElementKind::from_str(tag)
+                                        .expect("failed to convert string to ElementKind");
+                                    token = self.t.next();
+                                    self.pop_until(element_kind);
+                                    continue;
+                                }
+                                "a" => {
+                                    let element_kind = ElementKind::from_str(tag)
+                                        .expect("failed to convert string to ElementKind");
+                                    token = self.t.next();
+                                    self.pop_until(element_kind);
+                                    continue;
+                                }
+                                _ => {
+                                    token = self.t.next();
+                                }
+                            }
+                        }
+                        Some(HtmlToken::Eof) | None => {
+                            return self.window.clone();
+                        }
+                        Some(HtmlToken::Char(c)) => {
+                            // テキストは現在の挿入先に連結（coalescing）される。
+                            self.insert_char(c);
+                            token = self.t.next();
+                            continue;
+                        }
+                    }
+                }
+
+                // styleタグとscriptタグが開始した後の状態
+                // 終了タグが出るまで、文字をテキストノードとしてDOMツリーに追加する
+                InsertionMode::Text => {
+                    // <style> / <script> の中身を「文字列として」追加する（終了タグまで）。
+                    match token {
+                        Some(HtmlToken::Eof) | None => {
+                            return self.window.clone();
+                        }
+                        Some(HtmlToken::EndTag { ref tag }) => {
+                            if tag == "style" {
+                                // style終了タグ
+                                self.pop_until(ElementKind::Style);
+                                self.mode = self.original_insertion_mode;
+                                token = self.t.next();
+                                continue;
+                            }
+                            if tag == "script" {
+                                // script終了タグ
+                                self.pop_until(ElementKind::Script);
+                                self.mode = self.original_insertion_mode;
+                                token = self.t.next();
+                                continue;
+                            }
+                        }
+                        Some(HtmlToken::Char(c)) => {
+                            // 終了タグが出てくるまでDOMツリーに追加する
+                            self.insert_char(c);
+                            token = self.t.next();
+                            continue;
+                        }
+                        _ => {}
+                    }
+
+                    self.mode = self.original_insertion_mode;
+                }
+
+                // html終了タグをあつかう
+                InsertionMode::AfterBody => {
+                    // 本文の後。/html で AfterAfterBody へ、文字は無視。
+                    match token {
+                        Some(HtmlToken::Char(_c)) => {
+                            // 次のトークンが文字トークンの時。無視して次のトークンへ
+                            token = self.t.next();
+                            continue;
+                        }
+                        Some(HtmlToken::EndTag { ref tag }) => {
+                            // EndTagでタグの名前がhtmlの時。AfterAfterBodyへ
+                            if tag == "html" {
+                                self.mode = InsertionMode::AfterAfterBody;
+                                token = self.t.next();
+                                continue;
+                            }
+                        }
+                        Some(HtmlToken::Eof) | None => {
+                            // それ以外の時はInBodyへ
+                            return self.window.clone();
+                        }
+                        _ => {}
+                    }
+
+                    self.mode = InsertionMode::InBody;
+                }
+
+                // トークンが終了することを確認し、パースを終了する
+                InsertionMode::AfterAfterBody => {
+                    // 完全終端の最終確認モード。EoF なら終了、文字は無視。
+                    match token {
+                        Some(HtmlToken::Char(_c)) => {
+                            // トークンが文字トークンの時、無視して次へ
+                            token = self.t.next();
+                            continue;
+                        }
+                        Some(HtmlToken::Eof) | None => {
+                            // EoFまたはトークンが存在しない時、DOMツリーを返す
+                            return self.window.clone();
+                        }
+                        _ => {}
+                    }
+
+                    // パースの失敗
+                    self.mode = InsertionMode::InBody;
+                }
+            }
+        }
+
+        // ループ外（保険）。ここに来る場合は入力が尽きている想定。
+        self.window.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::alloc::string::ToString;
+    use alloc::vec;
+
+    #[test]
+    fn test_empty() {
+        // 準備: 空文字（= 空のHTML）を入力にする
+        let html = "".to_string();
+        // トークナイザを作成（文字が無いので最初から EOF 相当）
+        let t = HtmlTokenizer::new(html);
+        // ツリービルダーで DOM を構築（省略ルールにより最低限の Document だけができる想定）
+        let window = HtmlParser::new(t).construct_tree();
+
+        // 期待: ルートは空の Document ノード
+        let expected = Rc::new(RefCell::new(Node::new(NodeKind::Document)));
+
+        // 検証: window.document() が Document 単体であること
+        assert_eq!(expected, window.borrow().document());
+    }
+
+    #[test]
+    fn test_body() {
+        // 準備: 最小の骨組みを満たす HTML（html/head/body を明示）
+        // 具体例の入力文字列:
+        //   "<html><head></head><body></body></html>"
+        // 期待するDOM構造（値を含む）:
+        //   Document
+        //   └─ Element("html")
+        //      ├─ Element("head")
+        //      └─ Element("body")
+        let html = "<html><head></head><body></body></html>".to_string();
+        // トークナイズ → ツリービルド（DOM 構築）
+        let t = HtmlTokenizer::new(html);
+        let window = HtmlParser::new(t).construct_tree();
+        let document = window.borrow().document();
+        // 期待: ルートは Document ノード（NodeKind::Document）
+        assert_eq!(
+            Rc::new(RefCell::new(Node::new(NodeKind::Document))),
+            document
+        );
+
+        // Document の最初の子は Element("html")。
+        // ここで `first_child()` は `Option<Rc<RefCell<Node>>>` を返すため、
+        // `expect` で Some を取り出し、`assert_eq!` では右辺も Rc<RefCell<Node>> で作っています。
+        let html = document
+            .borrow()
+            .first_child()
+            .expect("failed to get a first child of document");
+        assert_eq!(
+            Rc::new(RefCell::new(Node::new(NodeKind::Element(Element::new(
+                "html",
+                Vec::new()
+            ))))),
+            html
+        );
+
+        // Element("html") の最初の子は Element("head")。
+        // 具体的な値: タグ名は "head"、属性は空の Vec（[]）。
+        let head = html
+            .borrow()
+            .first_child()
+            .expect("failed to get a first child of html");
+        assert_eq!(
+            Rc::new(RefCell::new(Node::new(NodeKind::Element(Element::new(
+                "head",
+                Vec::new()
+            ))))),
+            head
+        );
+
+        // Element("head") の次の兄弟は Element("body")。
+        // 具体的な値: タグ名は "body"、属性は空の Vec（[]）。
+        let body = head
+            .borrow()
+            .next_sibling()
+            .expect("failed to get a next sibling of head");
+        assert_eq!(
+            Rc::new(RefCell::new(Node::new(NodeKind::Element(Element::new(
+                "body",
+                Vec::new()
+            ))))),
+            body
+        );
+    }
+
+    #[test]
+    fn test_text() {
+        // 準備: body 内にテキスト "text" を含む HTML
+        // 入力文字列:
+        //   "<html><head></head><body>text</body></html>"
+        // 期待するDOM:
+        //   Document
+        //   └─ Element("html")
+        //      ├─ Element("head")
+        //      └─ Element("body")
+        //         └─ Text("text")
+        let html = "<html><head></head><body>text</body></html>".to_string();
+        // トークナイズ → ツリービルド
+        let t = HtmlTokenizer::new(html);
+        let window = HtmlParser::new(t).construct_tree();
+        let document = window.borrow().document();
+        // ルートは Document
+        assert_eq!(
+            Rc::new(RefCell::new(Node::new(NodeKind::Document))),
+            document
+        );
+
+        // Document の最初の子は Element("html")（属性は空の Vec）
+        let html = document
+            .borrow()
+            .first_child()
+            .expect("failed to get a first child of document");
+        assert_eq!(
+            Rc::new(RefCell::new(Node::new(NodeKind::Element(Element::new(
+                "html",
+                Vec::new()
+            ))))),
+            html
+        );
+
+        // html の最初の子は head、その次の兄弟が body（どちらも属性は空）
+        let body = html
+            .borrow()
+            .first_child()
+            .expect("failed to get a first child of document")
+            .borrow()
+            .next_sibling()
+            .expect("failed to get a next sibling of head");
+        assert_eq!(
+            Rc::new(RefCell::new(Node::new(NodeKind::Element(Element::new(
+                "body",
+                Vec::new()
+            ))))),
+            body
+        );
+
+        // body の最初の子は Text("text")
+        // 具体値: 文字列内容が "text" であることを検証
+        let text = body
+            .borrow()
+            .first_child()
+            .expect("failed to get a first child of document");
+        assert_eq!(
+            Rc::new(RefCell::new(Node::new(NodeKind::Text("text".to_string())))),
+            text
+        );
+    }
+
+    #[test]
+    fn test_multiple_nodes() {
+        // 準備: 入れ子構造と属性を含む HTML
+        // 入力:
+        //   "<html><head></head><body><p><a foo=bar>text</a></p></body></html>"
+        // 期待DOM（値付き）:
+        //   Document
+        //   └─ Element("html")
+        //      ├─ Element("head")
+        //      └─ Element("body")
+        //         └─ Element("p")
+        //            └─ Element("a", attrs=[("foo","bar")])
+        //               └─ Text("text")
+        let html = "<html><head></head><body><p><a foo=bar>text</a></p></body></html>".to_string();
+        let t = HtmlTokenizer::new(html);
+        let window = HtmlParser::new(t).construct_tree();
+        let document = window.borrow().document();
+
+        // Document → html → head → body と辿る。
+        // ここでは一気に first_child() → first_child() → next_sibling() で body を取得:
+        // - document.first_child() = html
+        // - html.first_child()     = head
+        // - head.next_sibling()    = body
+        let body = document
+            .borrow()
+            .first_child()
+            .expect("failed to get a first child of document")
+            .borrow()
+            .first_child()
+            .expect("failed to get a first child of document")
+            .borrow()
+            .next_sibling()
+            .expect("failed to get a next sibling of head");
+        assert_eq!(
+            Rc::new(RefCell::new(Node::new(NodeKind::Element(Element::new(
+                "body",
+                Vec::new()
+            ))))),
+            body
+        );
+
+        // body の最初の子は p 要素（属性は空）
+        let p = body
+            .borrow()
+            .first_child()
+            .expect("failed to get a first child of body");
+        assert_eq!(
+            Rc::new(RefCell::new(Node::new(NodeKind::Element(Element::new(
+                "p",
+                Vec::new()
+            ))))),
+            p
+        );
+
+        // 期待する a の属性: foo=bar
+        // Attribute::new() で空の属性を作り、add_char で name/value を1文字ずつ構築。
+        //   is_name=true  で name 側（"foo"）
+        //   is_name=false で value 側（"bar"）
+        let mut attr = Attribute::new();
+        attr.add_char('f', true);
+        attr.add_char('o', true);
+        attr.add_char('o', true);
+        attr.add_char('b', false);
+        attr.add_char('a', false);
+        attr.add_char('r', false);
+        // p の最初の子は a 要素で、属性に [ ("foo","bar") ] を持つ想定
+        let a = p
+            .borrow()
+            .first_child()
+            .expect("failed to get a first child of p");
+        assert_eq!(
+            Rc::new(RefCell::new(Node::new(NodeKind::Element(Element::new(
+                "a",
+                vec![attr]
+            ))))),
+            a
+        );
+
+        // a の最初の子は Text("text")
+        let text = a
+            .borrow()
+            .first_child()
+            .expect("failed to get a first child of a");
+        assert_eq!(
+            Rc::new(RefCell::new(Node::new(NodeKind::Text("text".to_string())))),
+            text
+        );
+    }
+}

--- a/saba/saba_core/src/renderer/html/token.rs
+++ b/saba/saba_core/src/renderer/html/token.rs
@@ -1,0 +1,769 @@
+//! HTML トークナイザ（初心者向け解説つき）
+//!
+//! これは HTML の文字列を「トークン（部品）」に分割する最小実装です。
+//! 文字を1つずつ読み進め、状態(State)に応じて `StartTag` / `EndTag` / `Char` / `Eof` を返します。
+//!
+//! サンプル（入力 → トークン列）
+//! ```text
+//! 入力: <div class="a">hi</div>
+//! 出力: StartTag { tag: "div", attributes: [("class","a")], self_closing: false }
+//!         Char('h')
+//!         Char('i')
+//!         EndTag { tag: "div" }
+//! ```
+//!
+//! もう少し詳しい流れ（divの開始タグ部分）
+//! ```text
+//! 1) '<' 読む → state=TagOpen
+//! 2) 'd' 読む（英字）→ reconsume=true, state=TagName, create_tag(Start)
+//! 3) TagName で 'd','i','v' を順に append_tag_name
+//! 4) 空白 ' ' → state=BeforeAttributeName
+//! 5) 'c' を再読（reconsume）させて state=AttributeName、属性を開始 start_new_attribute
+//! 6) AttributeName: 'c','l','a','s','s' を追加 → '=' で BeforeAttributeValue
+//! 7) '"' → AttributeValueDoubleQuoted、'a' を読み、'"' で閉じる
+//! 8) '>' → take_latest_token() で StartTag を返す
+//! ```
+//!
+//! コード例（イテレータとして使う）
+//! ```ignore
+//! use saba_core::renderer::html::token::{HtmlTokenizer, HtmlToken};
+//! let mut it = HtmlTokenizer::new("<br/>".to_string());
+//! assert!(matches!(it.next(), Some(HtmlToken::StartTag{ tag, self_closing: true, .. }) if tag == "br"));
+//! assert!(it.next().is_none());
+//! ```
+//!
+//! reconsume の意図
+//! - 「読み取り位置は進めたが、その文字を次の状態でもう一度処理したい」ときに使います。
+//!   読み過ぎを戻すのではなく、“もう一度使う”という設計にすると実装が単純になります。
+//!
+//! 設計メモ
+//! - 仕様準拠というより“状態機械”の学習が目的の最小版です。
+//! - エスケープ・エンティティ・コメント等は省略。必要になったら `State` と分岐を追加して拡張できます。
+//!
+//! 用語の橋渡し（TS / Python / Go）
+//! - イテレータ: `impl Iterator for HtmlTokenizer` により `next()` で 1 トークンずつ取得。
+//!   - TS: `for (const t of tokenizer) { ... }`、Python: `for t in tokenizer:`、Go: `for { t, ok := it.Next() }` 的な感覚。
+//! - 再読（reconsume）: 1 文字読み過ぎたときに「もう一度同じ文字を処理する」ためのフラグです。
+//! - 状態機械: 仕様（WHATWG）の各ステートを Rust の `enum State` で表し、`match` で分岐します。
+//!
+//! 注意
+//! - 学習用の簡易実装であり、仕様のサブセットです。スクリプトデータ周りなどは最小限です。
+//! - `Eof` トークンは内部の一部分岐でのみ生成されます。反復終了は `Iterator::next()` が `None` を返すことでも表されます。
+
+use crate::renderer::html::attribute::Attribute;
+use alloc::string::String;
+use alloc::vec::Vec;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HtmlToken {
+    // 開始タグ（例: <div class="a">）
+    StartTag {
+        tag: String,
+        self_closing: bool,
+        attributes: Vec<Attribute>,
+    },
+    // 終了タグ（例: </div>）
+    EndTag {
+        tag: String,
+    },
+    // テキストノードの 1 文字（例: 'h'）
+    Char(char),
+    // ファイルの終了（End Of File）。Iterator の `None` と併用されます。
+    Eof,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum State {
+    /// https://html.spec.whatwg.org/multipage/parsing.html#data-state
+    Data,
+    /// https://html.spec.whatwg.org/multipage/parsing.html#tag-open-state
+    TagOpen,
+    /// https://html.spec.whatwg.org/multipage/parsing.html#end-tag-open-state
+    EndTagOpen,
+    /// https://html.spec.whatwg.org/multipage/parsing.html#tag-name-state
+    TagName,
+    /// https://html.spec.whatwg.org/multipage/parsing.html#before-attribute-name-state
+    BeforeAttributeName,
+    /// https://html.spec.whatwg.org/multipage/parsing.html#attribute-name-state
+    AttributeName,
+    /// https://html.spec.whatwg.org/multipage/parsing.html#after-attribute-name-state
+    AfterAttributeName,
+    /// https://html.spec.whatwg.org/multipage/parsing.html#before-attribute-value-state
+    BeforeAttributeValue,
+    /// https://html.spec.whatwg.org/multipage/parsing.html#attribute-value-(double-quoted)-state
+    AttributeValueDoubleQuoted,
+    /// https://html.spec.whatwg.org/multipage/parsing.html#attribute-value-(single-quoted)-state
+    AttributeValueSingleQuoted,
+    /// https://html.spec.whatwg.org/multipage/parsing.html#attribute-value-(unquoted)-state
+    AttributeValueUnquoted,
+    /// https://html.spec.whatwg.org/multipage/parsing.html#after-attribute-value-(quoted)-state
+    AfterAttributeValueQuoted,
+    /// https://html.spec.whatwg.org/multipage/parsing.html#self-closing-start-tag-state
+    SelfClosingStartTag,
+    /// https://html.spec.whatwg.org/multipage/parsing.html#script-data-state
+    ScriptData,
+    /// https://html.spec.whatwg.org/multipage/parsing.html#script-data-less-than-sign-state
+    ScriptDataLessThanSign,
+    /// https://html.spec.whatwg.org/multipage/parsing.html#script-data-end-tag-open-state
+    ScriptDataEndTagOpen,
+    /// https://html.spec.whatwg.org/multipage/parsing.html#script-data-end-tag-name-state
+    ScriptDataEndTagName,
+    /// https://html.spec.whatwg.org/multipage/parsing.html#temporary-buffer
+    TemporaryBuffer,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HtmlTokenizer {
+    state: State,                    // 現在の状態（状態機械）
+    pos: usize,                      // 次に読む入力位置（0..len）。`next()`ごとに進みます。
+    reconsume: bool,                 // 直前に読んだ文字を“もう一度この状態で”処理したいとき true
+    latest_token: Option<HtmlToken>, // 生成途中のタグトークンを保持
+    input: Vec<char>,                // 入力全体を char ベクタ化したもの
+    buf: String,                     // スクリプトデータ等で一時的に使うバッファ
+}
+
+impl HtmlTokenizer {
+    /// 文字列からトークナイザを作成します。
+    ///
+    /// - 内部では `html.chars().collect()` でいったん `Vec<char>` を作ります。
+    ///   実装をシンプルにする代わりに、UTF-8 の 1 文字ずつに事前分割します（速度より分かりやすさ優先）。
+    /// - 初期状態は `State::Data`（タグの外のテキスト処理）。
+    ///
+    /// 例:
+    /// ```ignore
+    /// let mut it = HtmlTokenizer::new("<p>hi</p>".to_string());
+    /// assert!(it.next().is_some()); // StartTag("p")
+    /// ```
+    pub fn new(html: String) -> Self {
+        Self {
+            state: State::Data,
+            pos: 0,
+            reconsume: false,
+            latest_token: None,
+            input: html.chars().collect(),
+            buf: String::new(),
+        }
+    }
+
+    /// 入力の終端かどうか判定します。
+    ///
+    /// - `pos > input.len()` のとき true。
+    /// - 通常は `next()` の外側で境界管理しているため、ここは“安全確認”的な用途です。
+    fn is_eof(&self) -> bool {
+        self.pos > self.input.len()
+    }
+
+    /// 直前の1文字を“もう一度”返します（`reconsume = true` のとき専用）。
+    ///
+    /// - この関数は `pos` を進めません（読み取り位置は据え置き）。
+    /// - 直前に `consume_next_input()` を呼んでいることが前提です（そうでないと `pos-1` が underflow）。
+    /// - 呼び出し後は `reconsume` を自動で `false` に戻します。
+    fn reconsume_input(&mut self) -> char {
+        self.reconsume = false;
+        self.input[self.pos - 1]
+    }
+
+    /// 次の1文字を返し、`pos` を 1 進めます。
+    ///
+    /// - 事前に `pos < input.len()` が成り立っている必要があります（`next()` が保証）。
+    /// - UTF-8 の1文字単位で進みます（`.chars()` 済みのため）。
+    fn consume_next_input(&mut self) -> char {
+        let c = self.input[self.pos];
+        self.pos += 1;
+        c
+    }
+
+    /// StartTag/EndTag の生成を開始し、`latest_token` に仮置きします。
+    ///
+    /// - `start_tag_token=true` なら空の StartTag を、false なら空の EndTag を作ります。
+    /// - タグ名は空文字で開始し、`append_tag_name` で1文字ずつ積みます。
+    fn create_tag(&mut self, start_tag_token: bool) {
+        if start_tag_token {
+            self.latest_token = Some(HtmlToken::StartTag {
+                tag: String::new(),
+                self_closing: false,
+                attributes: Vec::new(),
+            });
+        } else {
+            self.latest_token = Some(HtmlToken::EndTag { tag: String::new() })
+        }
+    }
+
+    /// 生成中のタグ名に1文字追加します。
+    ///
+    /// - 事前条件: `latest_token` が `Some(StartTag|EndTag)` であること。
+    /// - 大文字→小文字化は呼び出し元（状態機械側）で行います。
+    /// - 不変条件が崩れた場合は `assert!` / `panic!` で早期に気づけるようにしています（学習用）。
+    fn append_tag_name(&mut self, c: char) {
+        assert!(self.latest_token.is_some());
+
+        if let Some(t) = self.latest_token.as_mut() {
+            match t {
+                HtmlToken::StartTag {
+                    ref mut tag,
+                    self_closing: _,
+                    attributes: _,
+                }
+                | HtmlToken::EndTag { ref mut tag } => tag.push(c),
+                _ => panic!("`latest_token` should be either StartTag or EndTag"),
+            }
+        }
+    }
+
+    /// 生成中の `latest_token` を取り出して返し、内部は `None` に戻します。
+    ///
+    /// - 事前条件: `latest_token.is_some()`。
+    /// - 返り値: 完成したタグトークン（`StartTag` または `EndTag`）。
+    fn take_latest_token(&mut self) -> Option<HtmlToken> {
+        assert!(self.latest_token.is_some());
+
+        let t = self.latest_token.as_ref().cloned();
+        self.latest_token = None;
+        assert!(self.latest_token.is_none());
+
+        t
+    }
+
+    /// 新しい属性を開始します（`StartTag.attributes` に空の Attribute を push）。
+    ///
+    /// - 事前条件: `latest_token` が `Some(StartTag)`。
+    /// - 値や名前の実体は `append_attribute` で 1 文字ずつ追加します。
+    fn start_new_attribute(&mut self) {
+        assert!(self.latest_token.is_some());
+
+        if let Some(t) = self.latest_token.as_mut() {
+            match t {
+                HtmlToken::StartTag {
+                    tag: _,
+                    self_closing: _,
+                    ref mut attributes,
+                } => {
+                    attributes.push(Attribute::new());
+                }
+                _ => panic!("`latest_token` should be either StartTag"),
+            }
+        }
+    }
+
+    /// 現在の属性の name/value のどちらかに 1 文字を追加します。
+    ///
+    /// - `is_name=true` で属性名、`false` で属性値に追加。
+    /// - 事前条件: `attributes.len() > 0`（直前に `start_new_attribute()` を呼んでいる）。
+    fn append_attribute(&mut self, c: char, is_name: bool) {
+        assert!(self.latest_token.is_some());
+
+        if let Some(t) = self.latest_token.as_mut() {
+            match t {
+                HtmlToken::StartTag {
+                    tag: _,
+                    self_closing: _,
+                    ref mut attributes,
+                } => {
+                    let len = attributes.len();
+                    assert!(len > 0);
+                    attributes[len - 1].add_char(c, is_name)
+                }
+                _ => panic!("`latest_token` should be either StartTag"),
+            }
+        }
+    }
+
+    /// 現在の StartTag を自己終了（`<br/>` など）としてマークします。
+    ///
+    /// - 事前条件: `latest_token` が `Some(StartTag)`。
+    /// - これにより返されるトークンの `self_closing` が `true` になります。
+    fn set_self_closing_flag(&mut self) {
+        assert!(self.latest_token.is_some());
+
+        if let Some(t) = self.latest_token.as_mut() {
+            match t {
+                HtmlToken::StartTag {
+                    tag: _,
+                    ref mut self_closing,
+                    attributes: _,
+                } => *self_closing = true,
+                _ => panic!("`latest_token` should be either StartTag"),
+            }
+        }
+    }
+}
+
+impl Iterator for HtmlTokenizer {
+    type Item = HtmlToken;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // 反復が終わったら None（イテレータの終了）を返します。
+        // この関数は「最大で1つのトークン」を返すのがルールです。
+        // - Some(token) を返したら一旦呼び出し側へ制御を返します（次の next() で続き）。
+        // - まだトークンが確定しない場合は `continue` で次の文字へ進みます。
+        if self.pos >= self.input.len() {
+            return None;
+        }
+
+        loop {
+            // reconsume が true のときは直前文字を「同じ位置のまま」もう一度処理します。
+            // 読み過ぎを戻すのではなく、“この文字を次の状態で使い直す”という設計です。
+            let c = match self.reconsume {
+                true => self.reconsume_input(),
+                false => self.consume_next_input(),
+            };
+
+            match self.state {
+                State::Data => {
+                    // 通常のテキスト（タグ外）を処理する状態。
+                    if c == '<' {
+                        self.state = State::TagOpen;
+                        continue; // まだトークンは返さず、次の文字でタグかどうかを判断
+                    }
+
+                    if self.is_eof() {
+                        return Some(HtmlToken::Eof);
+                    }
+
+                    return Some(HtmlToken::Char(c)); // ここで1文字ぶんのトークンを確定して返す
+                }
+
+                State::TagOpen => {
+                    // `<` の直後に来る文字で分岐：`/` なら終了タグ、英字なら開始タグ。
+                    if c == '/' {
+                        self.state = State::EndTagOpen;
+                        continue;
+                    }
+
+                    if c.is_ascii_alphabetic() {
+                        self.reconsume = true; // 同じ文字を TagName で一文字目として処理
+                        self.state = State::TagName;
+                        self.create_tag(true);
+                        continue;
+                    }
+
+                    if self.is_eof() {
+                        return Some(HtmlToken::Eof);
+                    }
+
+                    self.reconsume = true; // データとして扱い直す
+                    self.state = State::Data;
+                }
+
+                State::EndTagOpen => {
+                    // `</` の直後：タグ名開始
+                    if self.is_eof() {
+                        return Some(HtmlToken::Eof);
+                    }
+
+                    if c.is_ascii_alphabetic() {
+                        self.reconsume = true;
+                        self.state = State::TagName;
+                        self.create_tag(false);
+                        continue;
+                    }
+                }
+
+                State::TagName => {
+                    // タグ名を読み取る。
+                    // - 空白で属性（BeforeAttributeName）
+                    // - '/' で自己終了（SelfClosingStartTag）
+                    // - '>' でタグ確定して Start/EndTag を返す
+                    if c == ' ' {
+                        self.state = State::BeforeAttributeName;
+                        continue;
+                    }
+
+                    if c == '/' {
+                        self.state = State::SelfClosingStartTag;
+                        continue;
+                    }
+
+                    if c == '>' {
+                        self.state = State::Data;
+                        return self.take_latest_token(); // latest_token を取り出して None に戻す
+                    }
+
+                    if c.is_ascii_uppercase() {
+                        self.append_tag_name(c.to_ascii_lowercase());
+                        continue;
+                    }
+
+                    if self.is_eof() {
+                        return Some(HtmlToken::Eof);
+                    }
+
+                    self.append_tag_name(c); // それ以外はタグ名の続きとして追加
+                }
+
+                State::BeforeAttributeName => {
+                    // 次の属性開始の前。空白をスキップし、属性名の最初の文字を reconsume して AttributeName へ。
+                    if c == '/' || c == '>' || self.is_eof() {
+                        self.reconsume = true;
+                        self.state = State::AfterAttributeName;
+                        continue;
+                    }
+
+                    self.reconsume = true;
+                    self.state = State::AttributeName;
+                    self.start_new_attribute(); // 空の Attribute を attributes へプッシュ
+                }
+
+                State::AttributeName => {
+                    // 属性名を読み取る。`=` で属性値へ、空白/`/`/`>` で属性名終了。
+                    if c == ' ' || c == '/' || c == '>' || self.is_eof() {
+                        self.reconsume = true;
+                        self.state = State::AfterAttributeName;
+                        continue;
+                    }
+
+                    if c == '=' {
+                        self.state = State::BeforeAttributeValue;
+                        continue;
+                    }
+
+                    if c.is_ascii_uppercase() {
+                        self.append_attribute(c.to_ascii_lowercase(), /*is_name*/ true);
+                        continue;
+                    }
+
+                    self.append_attribute(c, /*is_name*/ true); // name 側に1文字追加
+                }
+
+                State::AfterAttributeName => {
+                    // 属性名を読み終わった直後。`=` なら値、`/` なら自己終了、`>` ならタグ完了
+                    if c == ' ' {
+                        // 空白文字は無視する
+                        continue;
+                    }
+
+                    if c == '/' {
+                        self.state = State::SelfClosingStartTag;
+                        continue;
+                    }
+
+                    if c == '=' {
+                        self.state = State::BeforeAttributeValue;
+                        continue;
+                    }
+
+                    if c == '>' {
+                        self.state = State::Data;
+                        return self.take_latest_token();
+                    }
+
+                    if self.is_eof() {
+                        return Some(HtmlToken::Eof);
+                    }
+
+                    self.reconsume = true;
+                    self.state = State::AttributeName;
+                    self.start_new_attribute();
+                }
+
+                State::BeforeAttributeValue => {
+                    // 属性値の開始を待つ。引用符で始まれば対応するステートへ。
+                    if c == ' ' {
+                        // 空白文字は無視する
+                        continue;
+                    }
+
+                    if c == '"' {
+                        self.state = State::AttributeValueDoubleQuoted;
+                        continue;
+                    }
+
+                    if c == '\'' {
+                        self.state = State::AttributeValueSingleQuoted;
+                        continue;
+                    }
+
+                    self.reconsume = true;
+                    self.state = State::AttributeValueUnquoted;
+                }
+
+                State::AttributeValueDoubleQuoted => {
+                    // ダブルクォート囲みの属性値を処理。
+                    if c == '"' {
+                        self.state = State::AfterAttributeValueQuoted;
+                        continue;
+                    }
+
+                    if self.is_eof() {
+                        return Some(HtmlToken::Eof);
+                    }
+
+                    self.append_attribute(c, /*is_name*/ false); // value 側に1文字追加
+                }
+
+                State::AttributeValueSingleQuoted => {
+                    // シングルクォート囲みの属性値を処理。
+                    if c == '\'' {
+                        self.state = State::AfterAttributeValueQuoted;
+                        continue;
+                    }
+
+                    if self.is_eof() {
+                        return Some(HtmlToken::Eof);
+                    }
+
+                    self.append_attribute(c, /*is_name*/ false); // value 側に1文字追加
+                }
+
+                State::AttributeValueUnquoted => {
+                    // 非引用の属性値。空白/`>`/`/` などで値を閉じる。
+                    if c == ' ' {
+                        self.state = State::BeforeAttributeName;
+                        continue;
+                    }
+
+                    if c == '>' {
+                        self.state = State::Data;
+                        return self.take_latest_token();
+                    }
+
+                    if self.is_eof() {
+                        return Some(HtmlToken::Eof);
+                    }
+
+                    self.append_attribute(c, /*is_name*/ false); // value 側に1文字追加
+                }
+
+                State::AfterAttributeValueQuoted => {
+                    // 引用で閉じた直後。次の属性へ進むか、自己終了/終了を判定
+                    if c == ' ' {
+                        self.state = State::BeforeAttributeName;
+                        continue;
+                    }
+
+                    if c == '/' {
+                        self.state = State::SelfClosingStartTag;
+                        continue;
+                    }
+
+                    if c == '>' {
+                        self.state = State::Data;
+                        return self.take_latest_token();
+                    }
+
+                    if self.is_eof() {
+                        return Some(HtmlToken::Eof);
+                    }
+
+                    self.reconsume = true;
+                    self.state = State::BeforeAttributeName;
+                }
+
+                State::SelfClosingStartTag => {
+                    // `<br/>` の `/` を読んだ後。`>` で自己終了タグを確定。
+                    if c == '>' {
+                        self.set_self_closing_flag();
+                        self.state = State::Data;
+                        return self.take_latest_token();
+                    }
+
+                    if self.is_eof() {
+                        // invalid parse error.
+                        return Some(HtmlToken::Eof);
+                    }
+                }
+
+                State::ScriptData => {
+                    // `<script>` タグ内の簡易処理
+                    if c == '<' {
+                        self.state = State::ScriptDataLessThanSign;
+                        continue;
+                    }
+
+                    if self.is_eof() {
+                        return Some(HtmlToken::Eof);
+                    }
+
+                    return Some(HtmlToken::Char(c));
+                }
+
+                State::ScriptDataLessThanSign => {
+                    // `<script>` 内で `<` を見たところ
+                    if c == '/' {
+                        // 一時的なバッファを空文字でリセットする
+                        self.buf = String::new();
+                        self.state = State::ScriptDataEndTagOpen;
+                        continue;
+                    }
+
+                    self.reconsume = true;
+                    self.state = State::ScriptData;
+                    return Some(HtmlToken::Char('<'));
+                }
+
+                State::ScriptDataEndTagOpen => {
+                    // `</` の後。タグ名に入るか、テキストに戻るか
+                    if c.is_ascii_alphabetic() {
+                        self.reconsume = true;
+                        self.state = State::ScriptDataEndTagName;
+                        self.create_tag(false);
+                        continue;
+                    }
+
+                    self.reconsume = true;
+                    self.state = State::ScriptData;
+                    // 仕様では、"<"と"/"の2つの文字トークンを返すとなっているが、
+                    // 私たちの実装ではnextメソッドからは一つのトークンしか返せない
+                    // ため、"<"のトークンのみを返す
+                    return Some(HtmlToken::Char('<'));
+                }
+
+                State::ScriptDataEndTagName => {
+                    // スクリプトの終了タグ名を読み取る
+                    if c == '>' {
+                        self.state = State::Data;
+                        return self.take_latest_token();
+                    }
+
+                    if c.is_ascii_alphabetic() {
+                        self.buf.push(c);
+                        self.append_tag_name(c.to_ascii_lowercase());
+                        continue;
+                    }
+
+                    self.state = State::TemporaryBuffer;
+                    self.buf = String::from("</") + &self.buf;
+                    self.buf.push(c);
+                    continue;
+                }
+
+                State::TemporaryBuffer => {
+                    // 一時バッファを1文字ずつ吐き出してテキストに戻す
+                    self.reconsume = true;
+
+                    if self.buf.chars().count() == 0 {
+                        self.state = State::ScriptData;
+                        continue;
+                    }
+
+                    // remove the first char
+                    let c = self
+                        .buf
+                        .chars()
+                        .nth(0)
+                        .expect("self.buf should have at least 1 char");
+                    self.buf.remove(0);
+                    return Some(HtmlToken::Char(c));
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::alloc::string::ToString;
+    use alloc::vec;
+
+    #[test]
+    fn test_empty() {
+        let html = "".to_string();
+        let mut tokenizer = HtmlTokenizer::new(html);
+        assert!(tokenizer.next().is_none())
+    }
+
+    #[test]
+    fn test_start_and_end_tag() {
+        let html = "<body></body>".to_string();
+        let mut tokenizer = HtmlTokenizer::new(html);
+        let expected = [
+            HtmlToken::StartTag {
+                tag: "body".to_string(),
+                self_closing: false,
+                attributes: Vec::new(),
+            },
+            HtmlToken::EndTag {
+                tag: "body".to_string(),
+            },
+        ];
+
+        for e in expected {
+            assert_eq!(Some(e), tokenizer.next())
+        }
+    }
+
+    #[test]
+    fn test_attributes() {
+        let html = "<p class=\"A\" id='B' foo=bar></p>".to_string();
+        let mut tokenizer = HtmlTokenizer::new(html);
+        let mut attr1 = Attribute::new();
+        attr1.add_char('c', true);
+        attr1.add_char('l', true);
+        attr1.add_char('a', true);
+        attr1.add_char('s', true);
+        attr1.add_char('s', true);
+        attr1.add_char('A', false);
+
+        let mut attr2 = Attribute::new();
+        attr2.add_char('i', true);
+        attr2.add_char('d', true);
+        attr2.add_char('B', false);
+
+        let mut attr3 = Attribute::new();
+        attr3.add_char('f', true);
+        attr3.add_char('o', true);
+        attr3.add_char('o', true);
+        attr3.add_char('b', false);
+        attr3.add_char('a', false);
+        attr3.add_char('r', false);
+
+        let expected = [
+            HtmlToken::StartTag {
+                tag: "p".to_string(),
+                self_closing: false,
+                attributes: vec![attr1, attr2, attr3],
+            },
+            HtmlToken::EndTag {
+                tag: "p".to_string(),
+            },
+        ];
+
+        for e in expected {
+            assert_eq!(Some(e), tokenizer.next());
+        }
+    }
+
+    #[test]
+    fn test_self_closing_tag() {
+        let html = "<img />".to_string();
+        let mut tokenizer = HtmlTokenizer::new(html);
+        let expected = [HtmlToken::StartTag {
+            tag: "img".to_string(),
+            self_closing: true,
+            attributes: Vec::new(),
+        }];
+
+        for e in expected {
+            assert_eq!(Some(e), tokenizer.next())
+        }
+    }
+
+    #[test]
+    fn test_script_tag() {
+        let html = "<script>js code;</script>".to_string();
+        let mut tokenizer = HtmlTokenizer::new(html);
+        let expected = [
+            HtmlToken::StartTag {
+                tag: "script".to_string(),
+                self_closing: false,
+                attributes: Vec::new(),
+            },
+            HtmlToken::Char('j'),
+            HtmlToken::Char('s'),
+            HtmlToken::Char(' '),
+            HtmlToken::Char('c'),
+            HtmlToken::Char('o'),
+            HtmlToken::Char('d'),
+            HtmlToken::Char('e'),
+            HtmlToken::Char(';'),
+            HtmlToken::EndTag {
+                tag: "script".to_string(),
+            },
+        ];
+
+        for e in expected {
+            assert_eq!(Some(e), tokenizer.next())
+        }
+    }
+}

--- a/saba/saba_core/src/renderer/mod.rs
+++ b/saba/saba_core/src/renderer/mod.rs
@@ -1,0 +1,1 @@
+pub mod html;

--- a/saba/saba_core/src/renderer/mod.rs
+++ b/saba/saba_core/src/renderer/mod.rs
@@ -1,1 +1,2 @@
+pub mod dom;
 pub mod html;

--- a/saba/saba_core/src/renderer/mod.rs
+++ b/saba/saba_core/src/renderer/mod.rs
@@ -1,2 +1,3 @@
 pub mod dom;
 pub mod html;
+pub mod page;

--- a/saba/saba_core/src/renderer/page.rs
+++ b/saba/saba_core/src/renderer/page.rs
@@ -1,0 +1,70 @@
+//! Page — ブラウザの「1ページ」を表す最小モデル（初心者向け）
+//!
+//! 役割（実ブラウザでの位置づけ）
+//! - `Browser` が複数のページを管理し、その1枚が `Page` です。
+//! - ネットワーク層から受け取った HTTP レスポンス本文（HTML 文字列）を、
+//!   トークナイズ→パース（ツリービルド）して DOM（`Window`/`Document`）にします。
+//! - 本実装では描画の代わりに、デバッグ用のテキストに変換して返します。
+//!
+//! 言語ブリッジ（TS / Python / Go）
+//! - `Rc<RefCell<T>>`/`Weak<T>` は「共有 + 内部可変 / 循環参照回避」。
+//! - `receive_response` は“ページがネットワーク応答を受け取り、DOMを更新する”入口メソッド。
+//! - `create_frame` は“タブに表示するフレーム（Window）を作る”という意味合いです。
+
+use crate::alloc::string::ToString;
+use crate::browser::Browser;
+use crate::http::HttpResponse;
+use crate::renderer::dom::node::Window;
+use crate::renderer::html::parser::HtmlParser;
+use crate::renderer::html::token::HtmlTokenizer;
+use crate::utils::convert_dom_to_string;
+use alloc::rc::Rc;
+use alloc::rc::Weak;
+use alloc::string::String;
+use core::cell::RefCell;
+
+#[derive(Debug, Clone)]
+pub struct Page {
+    browser: Weak<RefCell<Browser>>,
+    frame: Option<Rc<RefCell<Window>>>,
+}
+
+impl Page {
+    // 新しい空のページを作成。まだブラウザやフレーム（Window）は紐づけられていません。
+    pub fn new() -> Self {
+        Self {
+            browser: Weak::new(),
+            frame: None,
+        }
+    }
+
+    // 所属ブラウザを弱参照でセット（循環参照回避）。
+    pub fn set_browser(&mut self, browser: Weak<RefCell<Browser>>) {
+        self.browser = browser;
+    }
+    // ネットワーク応答（HTTP）を受け取り、DOM を構築し、デバッグ文字列を返す。
+    // 実ブラウザではここから レンダリングツリー更新 → レイアウト → ペイント に進みますが、
+    // 本書の最小実装では "DOMをテキスト化して返す" までとします。
+    pub fn receive_response(&mut self, response: HttpResponse) -> String {
+        // 1) レスポンスの本文（HTML）からフレーム(Window)を作る
+        self.create_frame(response.body());
+
+        // 2) デバッグ用に DOM ツリーを文字列として返す
+        if let Some(frame) = &self.frame {
+            let dom = frame.borrow().document().clone();
+            let debug = convert_dom_to_string(&Some(dom));
+            return debug;
+        }
+
+        "".to_string()
+    }
+
+    // HTML 文字列からトークナイザ/パーサを組み合わせて Window（DOMツリー）を構築する。
+    // - HtmlTokenizer: 文字列 → トークン列（<tag>, </tag>, Char, Eof）
+    // - HtmlParser: トークン列 → DOMツリー（Window/Document/Element/Text）
+    fn create_frame(&mut self, html: String) {
+        let html_tokenizer = HtmlTokenizer::new(html);
+        let frame = HtmlParser::new(html_tokenizer).construct_tree();
+        self.frame = Some(frame);
+    }
+}

--- a/saba/saba_core/src/utils.rs
+++ b/saba/saba_core/src/utils.rs
@@ -1,0 +1,54 @@
+//! utils — デバッグ用ユーティリティ（DOM をインデント付きの文字列にする）
+//!
+//! 目的
+//! - `Node`（Document/Element/Text）の木構造を、人間が読みやすいテキストに変換します。
+//! - レンダリングの代わりに“DOM の概形”を確認する用途に使います。
+//!
+//! 出力イメージ
+//! ```text
+//! Document
+//!   Element(ElementKind::Html)
+//!     Element(ElementKind::Head)
+//!     Element(ElementKind::Body)
+//!       Text("hello")
+//! ```
+//!
+//! 言語ブリッジ（TS / Python / Go）
+//! - 再帰関数で「先に子、次に兄弟」を辿る前順走査の一種。
+//! - 文字列連結は `String`（所有文字列）を `push_str`/`push` で伸ばしていきます。
+
+use crate::renderer::dom::node::Node;
+use alloc::format;
+use alloc::rc::Rc;
+use alloc::string::String;
+use core::cell::RefCell;
+
+// ルートノード（Option<Rc<RefCell<Node>>>）から、インデント付きのツリー文字列を作る
+pub fn convert_dom_to_string(root: &Option<Rc<RefCell<Node>>>) -> String {
+    // 先頭に改行を入れて見やすくする（呼び出し側が println! で1行ずつ出すため）
+    let mut result = String::from("\n");
+    convert_dom_to_string_internal(root, 0, &mut result);
+    result
+}
+
+// 内部実装: 再帰で (1) 自分を出力 → (2) 最初の子へ（深さ+1） → (3) 次の兄弟へ（同じ深さ）
+fn convert_dom_to_string_internal(
+    node: &Option<Rc<RefCell<Node>>>,
+    depth: usize,
+    result: &mut String,
+) {
+    match node {
+        Some(n) => {
+            // 深さに応じて2スペースずつインデント
+            result.push_str(&"  ".repeat(depth));
+            // {:?} で NodeKind のデバッグ表現（Document/Element(...)/Text("...")）を出力
+            result.push_str(&format!("{:?}", n.borrow().kind()));
+            result.push('\n');
+            // 先に「最初の子」を深さ+1で出力（子孫をすべて出す）
+            convert_dom_to_string_internal(&n.borrow().first_child(), depth + 1, result);
+            // 次に「次の兄弟」を同じ深さで出力
+            convert_dom_to_string_internal(&n.borrow().next_sibling(), depth, result);
+        }
+        None => (),
+    }
+}


### PR DESCRIPTION
## これなに
これはHTMLのトークン分割からその解析を行うロジックを実装したPRです
HTMLコードをトークンで分けていき、それをトクナイザが理解するというロジックを実装しています

ここのロジックを実装することで、
`<p>hello world!</p>`
というHTMLコードを理解することができるようになります。