### PR TITLE
CSSのトークナイザおよび字句解析ロジックの実装

### DIFF
--- a/saba/saba_core/src/constants.rs
+++ b/saba/saba_core/src/constants.rs
@@ -1,0 +1,31 @@
+//! レイアウト/描画のための固定定数（サンプル用）
+//!
+//! ここではウィンドウやテキストの基本寸法を“仮固定値”として定義します。
+//! 実ブラウザのような DPI/フォントメトリクス/ズーム対応は行わず、分かりやすさを優先します。
+//! - すべて `i64` で表しており、ピクセル単位の簡易モデルです。
+
+// ウィンドウ全体のサイズ（ピクセル）
+pub static WINDOW_WIDTH: i64 = 600;
+pub static WINDOW_HEIGHT: i64 = 400;
+// ウィンドウ内側の余白（上下左右に同値を適用）
+pub static WINDOW_PADDING: i64 = 5;
+
+// noli ライブラリの UI 部分に合わせたメニューバー/ツールバー等の高さ
+// （このプロジェクトでは固定値として扱い、動的計測はしません）
+pub static TITLE_BAR_HEIGHT: i64 = 24;
+
+pub static TOOLBAR_HEIGHT: i64 = 26;
+
+// 実際にコンテンツ（HTML）が描画される領域のサイズ
+// - 横幅は左右のウィンドウ余白を差し引き
+// - 高さはタイトルバー/ツールバー/上下余白を差し引き
+pub static CONTENT_AREA_WIDTH: i64 = WINDOW_WIDTH - WINDOW_PADDING * 2;
+pub static CONTENT_AREA_HEIGHT: i64 =
+    WINDOW_HEIGHT - TITLE_BAR_HEIGHT - TOOLBAR_HEIGHT - WINDOW_PADDING * 2;
+
+// 等幅フォントの想定文字サイズ（ピクセル）
+// - 文字幅: 8px, 文字高: 16px（学習用の仮値）
+// - 行の高さ（行送り）は適当に +4px して “詰まりすぎない” 程度に余白を追加
+pub static CHAR_WIDTH: i64 = 8;
+pub static CHAR_HEIGHT: i64 = 16;
+pub static CHAR_HEIGHT_WITH_PADDING: i64 = CHAR_HEIGHT + 4;

--- a/saba/saba_core/src/display_item.rs
+++ b/saba/saba_core/src/display_item.rs
@@ -1,0 +1,41 @@
+//! DisplayItem — “描画命令”の最小表現（レンダリングの中間表現）
+//!
+//! 役割
+//! - レイアウト計算の結果（どこに/どのサイズで描くか）と、スタイル（色など）を束ねて
+//!   実際の描画バックエンドに渡しやすい形へ変換します。
+//! - 実ブラウザでいえば「描画リスト」「ディスプレイリスト」に相当する超簡易版です。
+//!
+//! 現在の種類（学習用）
+//! - `Rect` … 矩形の塗り潰しや背景など。スタイル一式 + 位置 + サイズを持ちます。
+//! - `Text` … 文字列の描画。テキスト内容 + スタイル + 位置を持ちます。
+//!
+//! 例（イメージ）
+//! - <p style="background-color:yellow">Hi</p>
+//!   → [
+//!        Rect { style(bg=yellow), point=(x,y), size=(w,h) },
+//!        Text { text="Hi", style(color=...), point=(x_text,y_text) }
+//!      ]
+use crate::renderer::layout::computed_style::ComputedStyle;
+use crate::renderer::layout::layout_object::LayoutPoint;
+use crate::renderer::layout::layout_object::LayoutSize;
+use alloc::string::String;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum DisplayItem {
+    Rect {
+        // 塗る/描くときに必要な CSS の最終的な値（色/フォントなど）
+        style: ComputedStyle,
+        // 左上座標（レイアウト座標系）
+        layout_point: LayoutPoint,
+        // 幅・高さ（ピクセル）
+        layout_size: LayoutSize,
+    },
+    Text {
+        // 描く文字列（等幅フォント前提の簡易モデル）
+        text: String,
+        // 文字色などのスタイル。
+        style: ComputedStyle,
+        // 左上座標（ベースラインではなく簡易に左上で扱う）
+        layout_point: LayoutPoint,
+    },
+}

--- a/saba/saba_core/src/lib.rs
+++ b/saba/saba_core/src/lib.rs
@@ -42,6 +42,7 @@ extern crate alloc; // no_std でも `String`/`Vec` を使うために必要
 
 pub mod browser;
 pub mod constants;
+pub mod display_item;
 pub mod error; // 共有エラー型（Result<T, Error> 用）
 pub mod http; // HTTP の型/処理（I/Oは含まない）
 pub mod renderer; // HTMLレンダリング

--- a/saba/saba_core/src/lib.rs
+++ b/saba/saba_core/src/lib.rs
@@ -41,6 +41,7 @@
 extern crate alloc; // no_std でも `String`/`Vec` を使うために必要
 
 pub mod browser;
+pub mod constants;
 pub mod error; // 共有エラー型（Result<T, Error> 用）
 pub mod http; // HTTP の型/処理（I/Oは含まない）
 pub mod renderer; // HTMLレンダリング

--- a/saba/saba_core/src/renderer/css/cssom.rs
+++ b/saba/saba_core/src/renderer/css/cssom.rs
@@ -1,0 +1,495 @@
+//! CSSOM（CSS Object Model）の最小実装（初心者向け）
+//!
+//! これは CSS の“見た目のオブジェクト表現”です。実ブラウザでは、文字列の CSS を
+//! 1) トークナイズ → 2) パース → 3) CSSOM（StyleSheet/Rule/Declaration など）
+//! に落とし込み、DOM と組み合わせてスタイル計算を行います。
+//!
+//! 対応関係（実CSSのどの部分？）
+//! - `StyleSheet` … スタイルシート全体。ファイル1枚・`<style>`1つ分。
+//!   例: `p { color: red; } h1 { font-size: 40; }`
+//! - `QualifiedRule` … 1つのルール。セレクタ + 宣言ブロックの組。
+//!   例: `p { color: red; }` が1ルール。
+//! - `Selector` … セレクタ。`p`, `.class`, `#id` など（ここでは3種を簡易対応）。
+//! - `Declaration` … 宣言1つ。プロパティ名と値のペア。
+//!   例: `color: red` は `property="color"`, `value=Ident("red")`。
+//!
+//! 言語ブリッジ（TS / Python / Go）
+//! - `StyleSheet.rules: Vec<QualifiedRule>` … 配列にルールが並ぶ（TS: QualifiedRule[]、Python: list）。
+//! - 値（`ComponentValue`）は現状 CSS トークンをそのまま使います（型の最小化）。
+//!   実用では `Length(px)`, `Color(Rgb)`, `String`, `Url` などの型に解釈します。
+//!
+//! 例（文字列→CSSOMのイメージ）
+//! ```text
+//! 入力:  p { color: red; }  h1 { font-size: 40; }
+//! CSSOM:
+//! StyleSheet {
+//!   rules: [
+//!     QualifiedRule { selector: TypeSelector("p"),  declarations: [
+//!       Declaration { property: "color", value: Ident("red") }
+//!     ] },
+//!     QualifiedRule { selector: TypeSelector("h1"), declarations: [
+//!       Declaration { property: "font-size", value: Number(40.0) }
+//!     ] }
+//!   ]
+//! }
+//! ```
+
+use crate::alloc::string::ToString;
+use crate::renderer::css::token::CssToken;
+use crate::renderer::css::token::CssTokenizer;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::iter::Peekable;
+
+#[derive(Debug, Clone)]
+pub struct CssParser {
+    t: Peekable<CssTokenizer>, // トークナイザを先読み可能に包む（lookahead が必要になるため）
+}
+
+impl CssParser {
+    pub fn new(t: CssTokenizer) -> Self {
+        Self { t: t.peekable() }
+    }
+
+    // 次のトークンを消費し、ComponentValueとして返す
+    /// 次のトークンを“そのまま”値として受け取る（ComponentValue = CssToken の簡易方針）
+    /// 例: `color: red;` の直後に `Ident("red")` が現れる想定。
+    /// 本格実装ではここで `CssToken` → `Value`（Color/Length/String 等）に解釈します。
+    /// 仕様: https://www.w3.org/TR/css-syntax-3/#consume-component-value
+    fn consume_component_value(&mut self) -> ComponentValue {
+        self.t
+            .next()
+            .expect("should have a token in consume_component_value")
+    }
+
+    // 識別子トークンを消費し、文字列を取得する
+    /// 入力例: `color: red` の `color` 部分や、`font-size` のようなプロパティ名。
+    /// 不正（Ident 以外）なら明確なメッセージで失敗させ、解析の不整合に気づけるようにします。
+    fn consume_ident(&mut self) -> String {
+        let token = match self.t.next() {
+            Some(t) => t,
+            None => panic!("should have a token but got None"),
+        };
+
+        match token {
+            CssToken::Ident(ref ident) => ident.to_string(),
+            _ => {
+                panic!("Parse error: {:?} is an unexpected token.", token);
+            }
+        }
+    }
+
+    // ひとつの宣言を解釈する
+    /// 入力例: `color: red;` → Declaration { property: "color", value: Ident("red") }
+    /// 仕様: https://www.w3.org/TR/css-syntax-3/#consume-a-declaration
+    fn consume_declaration(&mut self) -> Option<Declaration> {
+        if self.t.peek().is_none() {
+            return None;
+        }
+
+        // 1) Declaration 構造体を初期化する
+        let mut declaration = Declaration::new();
+        // 2) Declaration構造体のプロパティに識別子を設定する
+        declaration.set_property(self.consume_ident());
+
+        // 3) もし次のトークンがコロンでない場合、パースエラーなので、Noneを返す
+        match self.t.next() {
+            Some(token) => match token {
+                CssToken::Colon => {}
+                _ => return None,
+            },
+            None => return None,
+        }
+
+        // 4) Declaration構造体の値にコンポーネント値を設定する
+        declaration.set_value(self.consume_component_value());
+
+        Some(declaration)
+    }
+
+    // consume_list_of_declarationsでは、複数の宣言を解釈する
+    /// 入力例: `{ color: red; font-size: 40; }` → [Declaration("color", Ident("red")), Declaration("font-size", Number(40))]
+    /// 仕様: https://www.w3.org/TR/css-syntax-3/#consume-a-list-of-declarations
+    fn consume_list_of_declarations(&mut self) -> Vec<Declaration> {
+        let mut declarations = Vec::new(); // 宣言ベクタを初期化する
+
+        loop {
+            let token = match self.t.peek() {
+                Some(t) => t,
+                None => return declarations,
+            };
+
+            match token {
+                // 閉じ波括弧が現れるまで宣言を作成しベクタに追加する
+                CssToken::CloseCurly => {
+                    assert_eq!(self.t.next(), Some(CssToken::CloseCurly));
+                    return declarations;
+                }
+                // セミコロンのとき一つの宣言が終了したことを表す
+                CssToken::SemiColon => {
+                    assert_eq!(self.t.next(), Some(CssToken::SemiColon));
+                    // 一つの宣言が終了。何もしない（次のプロパティへ）
+                }
+                // 識別子トークンの時、一つの宣言を解釈し、ベクタに追加する
+                CssToken::Ident(ref _ident) => {
+                    if let Some(declaration) = self.consume_declaration() {
+                        declarations.push(declaration);
+                    }
+                }
+                _ => {
+                    self.t.next();
+                }
+            }
+        }
+    }
+
+    /// セレクタを 1 つ解釈する（Type / Class / ID の簡易版）
+    /// 入力例:
+    /// - `#main {` → IdSelector("main")
+    /// - `.note {` → ClassSelector("note")
+    /// - `a:hover {` → TypeSelector("a") として扱い、`:` 以降は `{` まで読み飛ばす（簡易）
+    fn consume_selector(&mut self) -> Selector {
+        let token = match self.t.next() {
+            Some(t) => t,
+            None => panic!("should have a token but got None"),
+        };
+
+        match token {
+            CssToken::HashToken(value) => Selector::IdSelector(value[1..].to_string()), // ハッシュトークンの時、IDセレクタを作成して返す（先頭の # を落とす）
+            CssToken::Delim(delim) => {
+                if delim == '.' {
+                    // ピリオドの時、クラスセレクタを作成して返す
+                    return Selector::ClassSelector(self.consume_ident());
+                }
+                panic!("Parse error: {:?} is an unexpected token.", token);
+            }
+            CssToken::Ident(ident) => {
+                // 識別子の時、タイプセレクタを作成して返す
+                // a:hoverのようなセレクタはタグ名のセレクタとして扱うため、
+                // もしコロン（:）が出てきた場合は宣言ブロックの開始直前まで
+                // トークンを進める
+                if self.t.peek() == Some(&CssToken::Colon) {
+                    while self.t.peek() != Some(&CssToken::OpenCurly) {
+                        self.t.next();
+                    }
+                }
+                Selector::TypeSelector(ident.to_string())
+            }
+            CssToken::AtKeyword(_keyword) => {
+                // @から始まるルールを無視するために、宣言ブロックの開始直前まで
+                // トークンを進める
+                while self.t.peek() != Some(&CssToken::OpenCurly) {
+                    self.t.next();
+                }
+                Selector::UnknownSelector
+            }
+            _ => {
+                self.t.next();
+                Selector::UnknownSelector
+            }
+        }
+    }
+
+    /// Qualified Rule（セレクタ + 宣言ブロック）を 1 つ解釈する
+    ///
+    /// 役割
+    /// - セレクタ部分を読み（例: `p`, `.note`, `#main`）、`{` が来たら宣言ブロックを `}` まで解釈します。
+    /// - 読み終えたら `Some(QualifiedRule)` を返し、入力が尽きたら `None` を返します。
+    ///
+    /// 入力例 → 出力イメージ
+    /// - `p { color: red; }` → selector=TypeSelector("p"), declarations=[ Declaration("color", Ident("red")) ]
+    /// - `.note { font-size: 40; }` → selector=ClassSelector("note"), declarations=[ Declaration("font-size", Number(40.0)) ]
+    ///
+    /// 関連仕様
+    /// - consume-qualified-rule: https://www.w3.org/TR/css-syntax-3/#consume-qualified-rule
+    /// - qualified-rule:         https://www.w3.org/TR/css-syntax-3/#qualified-rule
+    /// - style rules:            https://www.w3.org/TR/css-syntax-3/#style-rules
+    fn consume_qualified_rule(&mut self) -> Option<QualifiedRule> {
+        let mut rule = QualifiedRule::new();
+
+        loop {
+            let token = match self.t.peek() {
+                Some(t) => t,
+                None => return None,
+            };
+
+            match token {
+                CssToken::OpenCurly => {
+                    // `{` に到達 → 宣言ブロック開始。中身（declarations）を読み切って返す。
+                    assert_eq!(self.t.next(), Some(CssToken::OpenCurly));
+                    rule.set_declarations(self.consume_list_of_declarations());
+                    return Some(rule);
+                }
+                _ => {
+                    // それ以外の時、ルールのセレクタとして扱うためセレクタを解釈し、
+                    // ルールの selector フィールドに設定する。
+                    rule.set_selector(self.consume_selector());
+                }
+            }
+        }
+    }
+
+    /// スタイルルールの並びを EOF まで解釈する
+    ///
+    /// 役割
+    /// - 通常の style rule を次々に `consume_qualified_rule` で読み取り、ベクタに集めます。
+    /// - `@` で始まる at-rule（@import/@media 等）は本書の簡易実装では無視（読み飛ばし）の方針です。
+    ///
+    /// 入力例 → 出力イメージ
+    /// - `p{...} h1{...}` → vec![ QualifiedRule(p, ...), QualifiedRule(h1, ...) ]
+    ///
+    /// 仕様: https://www.w3.org/TR/css-syntax-3/#consume-a-list-of-rules
+    fn consume_list_of_rules(&mut self) -> Vec<QualifiedRule> {
+        // 空のベクタを作成する
+        let mut rules = Vec::new();
+
+        loop {
+            let token = match self.t.peek() {
+                Some(t) => t,
+                None => return rules,
+            };
+            match token {
+                // AtKeywordトークンが出てきた場合、他のCSSをインポートする@import、
+                // メディアクエリを表す@mediaなどのルールが始まることを表す
+                CssToken::AtKeyword(_keyword) => {
+                    let _rule = self.consume_qualified_rule();
+                    // しかし、本書のブラウザでは@から始まるルールはサポート
+                    // しないので、無視をする
+                }
+                _ => {
+                    // 1つの style rule を解釈し、成功したらベクタに追加する
+                    let rule = self.consume_qualified_rule();
+                    match rule {
+                        Some(r) => rules.push(r),
+                        None => return rules,
+                    }
+                }
+            }
+        }
+    }
+
+    /// スタイルシート全体を解釈し、StyleSheet を返す
+    ///
+    /// 役割
+    /// - 見出し（ルールの列）を `consume_list_of_rules` で構築し、`StyleSheet.rules` に設定します。
+    /// - この戻り値（CSSOM）は、後工程の「スタイル計算」（DOMとマッチングして計算）で用います。
+    ///
+    /// 仕様: https://www.w3.org/TR/css-syntax-3/#parse-stylesheet
+    pub fn parse_stylesheet(&mut self) -> StyleSheet {
+        // StyleSheet構造体のインスタンスを作成する
+        let mut sheet = StyleSheet::new();
+
+        // トークン列からルールのリストを作成し、StyleSheetのフィールドに設定する
+        sheet.set_rules(self.consume_list_of_rules());
+        sheet
+    }
+}
+
+/// https://www.w3.org/TR/cssom-1/#cssstylesheet
+#[derive(Debug, Clone, PartialEq)]
+pub struct StyleSheet {
+    /// https://drafts.csswg.org/cssom/#dom-cssstylesheet-cssrules
+    pub rules: Vec<QualifiedRule>, // スタイルシートに含まれるルール列（読み順）
+}
+
+impl StyleSheet {
+    pub fn new() -> Self {
+        Self { rules: Vec::new() }
+    }
+
+    pub fn set_rules(&mut self, rules: Vec<QualifiedRule>) {
+        self.rules = rules;
+    }
+}
+
+/// https://www.w3.org/TR/css-syntax-3/#qualified-rule
+#[derive(Debug, Clone, PartialEq)]
+pub struct QualifiedRule {
+    /// https://www.w3.org/TR/selectors-4/#typedef-selector-list
+    /// The prelude of the qualified rule is parsed as a <selector-list>.
+    pub selector: Selector, // セレクタ（簡易: 1つだけを保持。複合/コンビネータは未対応）
+    /// https://www.w3.org/TR/css-syntax-3/#parse-a-list-of-declarations
+    /// The content of the qualified rule’s block is parsed as a list of declarations.
+    pub declarations: Vec<Declaration>, // ブロック `{ ... }` 内の宣言一覧
+}
+
+impl QualifiedRule {
+    pub fn new() -> Self {
+        Self {
+            selector: Selector::TypeSelector("".to_string()),
+            declarations: Vec::new(),
+        }
+    }
+
+    pub fn set_selector(&mut self, selector: Selector) {
+        self.selector = selector;
+    }
+
+    pub fn set_declarations(&mut self, declarations: Vec<Declaration>) {
+        self.declarations = declarations;
+    }
+}
+
+/// https://www.w3.org/TR/selectors-4/
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Selector {
+    /// https://www.w3.org/TR/selectors-4/#type-selectors
+    TypeSelector(String), // 例: "p", "h1"
+    /// https://www.w3.org/TR/selectors-4/#class-html
+    ClassSelector(String), // 例: ".note" → ClassSelector("note") として保持
+    /// https://www.w3.org/TR/selectors-4/#id-selectors
+    IdSelector(String), // 例: "#main" → IdSelector("main") として保持
+    /// パース中にエラーが起こったときに使用されるセレクタ
+    UnknownSelector,
+}
+
+/// https://www.w3.org/TR/css-syntax-3/#declaration
+#[derive(Debug, Clone, PartialEq)]
+pub struct Declaration {
+    pub property: String,      // 例: "color", "font-size"
+    pub value: ComponentValue, // 例: Ident("red"), Number(40.0)
+}
+
+impl Declaration {
+    pub fn new() -> Self {
+        Self {
+            property: String::new(),
+            value: ComponentValue::Ident(String::new()),
+        }
+    }
+
+    pub fn set_property(&mut self, property: String) {
+        self.property = property;
+    }
+
+    pub fn set_value(&mut self, value: ComponentValue) {
+        self.value = value;
+    }
+}
+
+// 値（component value）を、まずは「CSSトークンそのもの」で持つ簡易版。
+// 例: Ident("red"), Number(40.0), StringToken("Hey").
+// 本格的には `enum Value { Color(Color), Length(Length), String(String), ... }`
+// のように意味のある型へ解釈していきます。
+pub type ComponentValue = CssToken;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+
+    #[test]
+    fn test_empty() {
+        // 準備: 空のスタイル文字列
+        let style = "".to_string();
+        // トークナイズ→パース（CSSOM化）
+        let t = CssTokenizer::new(style);
+        let cssom = CssParser::new(t).parse_stylesheet();
+
+        // 期待: ルールは 0 件（rules は空）
+        assert_eq!(cssom.rules.len(), 0);
+    }
+
+    #[test]
+    fn test_one_rule() {
+        // 準備: 単一ルール（要素セレクタ + 宣言1つ）
+        // 入力: p { color: red; }
+        let style = "p { color: red; }".to_string();
+        let t = CssTokenizer::new(style);
+        let cssom = CssParser::new(t).parse_stylesheet();
+
+        // 期待CSSOMを手で組み立てる
+        let mut rule = QualifiedRule::new();
+        rule.set_selector(Selector::TypeSelector("p".to_string()));
+        let mut declaration = Declaration::new();
+        declaration.set_property("color".to_string());
+        declaration.set_value(ComponentValue::Ident("red".to_string()));
+        rule.set_declarations(vec![declaration]);
+
+        let expected = [rule];
+        assert_eq!(cssom.rules.len(), expected.len());
+        for (got, exp) in cssom.rules.iter().zip(expected.iter()) {
+            assert_eq!(exp, got);
+        }
+    }
+
+    #[test]
+    fn test_id_selector() {
+        // 準備: ID セレクタ
+        // 入力: #id { color: red; }
+        // 期待: selector=IdSelector("id")（先頭の # を除いた値）
+        let style = "#id { color: red; }".to_string();
+        let t = CssTokenizer::new(style);
+        let cssom = CssParser::new(t).parse_stylesheet();
+
+        let mut rule = QualifiedRule::new();
+        rule.set_selector(Selector::IdSelector("id".to_string()));
+        let mut declaration = Declaration::new();
+        declaration.set_property("color".to_string());
+        declaration.set_value(ComponentValue::Ident("red".to_string()));
+        rule.set_declarations(vec![declaration]);
+
+        let expected = [rule];
+        assert_eq!(cssom.rules.len(), expected.len());
+        for (got, exp) in cssom.rules.iter().zip(expected.iter()) {
+            assert_eq!(exp, got);
+        }
+    }
+
+    #[test]
+    fn test_class_selector() {
+        // 準備: クラスセレクタ
+        // 入力: .class { color: red; }
+        // 期待: selector=ClassSelector("class")（先頭の '.' を除いた値）
+        let style = ".class { color: red; }".to_string();
+        let t = CssTokenizer::new(style);
+        let cssom = CssParser::new(t).parse_stylesheet();
+
+        let mut rule = QualifiedRule::new();
+        rule.set_selector(Selector::ClassSelector("class".to_string()));
+        let mut declaration = Declaration::new();
+        declaration.set_property("color".to_string());
+        declaration.set_value(ComponentValue::Ident("red".to_string()));
+        rule.set_declarations(vec![declaration]);
+
+        let expected = [rule];
+        assert_eq!(cssom.rules.len(), expected.len());
+        for (got, exp) in cssom.rules.iter().zip(expected.iter()) {
+            assert_eq!(exp, got);
+        }
+    }
+
+    #[test]
+    fn test_multiple_rules() {
+        // 準備: 複数ルールと異なる値型（StringToken/Number/Ident）の混在を検証
+        // 入力: p { content: "Hey"; } h1 { font-size: 40; color: blue; }
+        let style = "p { content: \"Hey\"; } h1 { font-size: 40; color: blue; }".to_string();
+        let t = CssTokenizer::new(style);
+        let cssom = CssParser::new(t).parse_stylesheet();
+
+        // 期待1: p { content: "Hey"; }
+        let mut rule1 = QualifiedRule::new();
+        rule1.set_selector(Selector::TypeSelector("p".to_string()));
+        let mut declaration1 = Declaration::new();
+        declaration1.set_property("content".to_string());
+        declaration1.set_value(ComponentValue::StringToken("Hey".to_string()));
+        rule1.set_declarations(vec![declaration1]);
+
+        // 期待2: h1 { font-size: 40; color: blue; }
+        let mut rule2 = QualifiedRule::new();
+        rule2.set_selector(Selector::TypeSelector("h1".to_string()));
+        let mut declaration2 = Declaration::new();
+        declaration2.set_property("font-size".to_string());
+        declaration2.set_value(ComponentValue::Number(40.0));
+        let mut declaration3 = Declaration::new();
+        declaration3.set_property("color".to_string());
+        declaration3.set_value(ComponentValue::Ident("blue".to_string()));
+        rule2.set_declarations(vec![declaration2, declaration3]);
+
+        let expected = [rule1, rule2];
+        assert_eq!(cssom.rules.len(), expected.len());
+        for (got, exp) in cssom.rules.iter().zip(expected.iter()) {
+            assert_eq!(exp, got);
+        }
+    }
+}

--- a/saba/saba_core/src/renderer/css/mod.rs
+++ b/saba/saba_core/src/renderer/css/mod.rs
@@ -1,0 +1,1 @@
+pub mod token;

--- a/saba/saba_core/src/renderer/css/mod.rs
+++ b/saba/saba_core/src/renderer/css/mod.rs
@@ -1,1 +1,2 @@
+pub mod cssom;
 pub mod token;

--- a/saba/saba_core/src/renderer/css/token.rs
+++ b/saba/saba_core/src/renderer/css/token.rs
@@ -1,0 +1,381 @@
+//! CSS トークナイザ（初心者向け）
+//!
+//! 目的
+//! - CSS の文字列を“トークン”（部品）に分解します。例: `color: #fff;` → `Ident("color")`, `Colon`,
+//!   `HashToken("fff")`, `SemiColon`。
+//! - ここで得たトークン列は、このあとセレクタ/宣言ブロックなどのパーサに渡されます。
+//!
+//! 言語ブリッジ（TS / Python / Go）
+//! - `Iterator` 実装により、`next()` で1トークンずつ取り出せます（TS の `for..of`、Python の `for x in it`）。
+//! - `String`/`Vec<char>` は `alloc` のヒープ型（no_std なので明示利用）。
+//! - 仕様リンク（W3C）を各トークン定義に添えていますが、実装は学習用に単純化しています。
+//!
+//! トークナイズの流れ（ざっくり）
+//! 1) 1文字読む → 種別を判定（記号/数字/識別子/文字列/特殊）
+//! 2) 必要なら `consume_xxx_token` で連続した塊を読み切る
+//! 3) 1トークンを返す（`Some(token)`）
+//! 4) 呼び出し側が `next()` を再度呼ぶ
+//!
+//! 簡易化している点（制約）
+//! - コメント `/* ... */` のスキップやバックスラッシュエスケープは未対応。
+//! - 数値の指数表記（1e3）や単位（px, em）は別フェーズで扱う前提。
+//! - `.` 単体は Delim とし、`.5` のような先頭ドット数値は未対応。
+//! - `-` 先頭の負数は未対応（`-` は識別子として扱う）。
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum CssToken {
+    /// https://www.w3.org/TR/css-syntax-3/#typedef-hash-token
+    /// 例: `#fff` → `HashToken("fff")`（本実装では常に ID/カラー風の文字列として扱う）
+    HashToken(String),
+    /// https://www.w3.org/TR/css-syntax-3/#typedef-delim-token
+    /// 単独記号。例: `,` や `.` など。
+    Delim(char),
+    /// https://www.w3.org/TR/css-syntax-3/#typedef-number-token
+    /// 数値。例: `12`, `0.5`。
+    Number(f64),
+    /// https://www.w3.org/TR/css-syntax-3/#typedef-colon-token
+    /// `:`（プロパティ名と値の区切り）
+    Colon,
+    /// https://www.w3.org/TR/css-syntax-3/#typedef-semicolon-token
+    /// `;`（宣言の終端）
+    SemiColon,
+    /// https://www.w3.org/TR/css-syntax-3/#tokendef-open-paren
+    /// `(`（関数呼び出しや `rgb(` など）
+    OpenParenthesis,
+    /// https://www.w3.org/TR/css-syntax-3/#tokendef-close-paren
+    /// `)`
+    CloseParenthesis,
+    /// https://www.w3.org/TR/css-syntax-3/#tokendef-open-curly
+    /// `{`（宣言ブロック開始）
+    OpenCurly,
+    /// https://www.w3.org/TR/css-syntax-3/#tokendef-close-curly
+    /// `}`（宣言ブロック終了）
+    CloseCurly,
+    /// https://www.w3.org/TR/css-syntax-3/#typedef-ident-token
+    /// 識別子。例: `color`, `background`, `--var`（本実装は英数字/`-`/`_` 程度に限定）
+    Ident(String),
+    /// https://www.w3.org/TR/css-syntax-3/#typedef-string-token
+    /// 引用符で囲まれた文字列。例: `"Helvetica"` → `StringToken("Helvetica")`
+    StringToken(String),
+    /// https://www.w3.org/TR/css-syntax-3/#typedef-at-keyword-token
+    /// `@xxx`。例: `@media`, `@import` → `AtKeyword("media")` など
+    AtKeyword(String),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CssTokenizer {
+    pos: usize,       // 次に読む位置（0..len）
+    input: Vec<char>, // 入力を1文字ずつに分割した配列（単純化のため事前に chars().collect()）
+}
+
+impl CssTokenizer {
+    /// 文字列からトークナイザを作成します。
+    /// - 内部では `chars().collect()` で `Vec<char>` を作り、`pos` を 0 から進めていきます。
+    pub fn new(css: String) -> Self {
+        Self {
+            pos: 0,
+            input: css.chars().collect(),
+        }
+    }
+
+    // 再びダブルクオーテーションまたはシングルクォーテーションが現れるまで入力を文字として解釈する
+    /// https://www.w3.org/TR/css-syntax-3/#consume-a-string-token
+    /// 例: `"Helvetica"` → `"Helvetica"`（両端の引用は除いた内容を返す）
+    /// 注意: この簡易実装では `\"` などのエスケープや改行・EOF の扱いを省略しています。
+    fn consume_string_token(&mut self) -> String {
+        let mut s = String::new();
+
+        loop {
+            if self.pos >= self.input.len() {
+                return s;
+            }
+
+            // 現在の引用符の次の文字から走査を開始する想定
+            self.pos += 1;
+            let c = self.input[self.pos];
+            match c {
+                '"' | '\'' => break,
+                _ => s.push(c),
+            }
+        }
+
+        s
+    }
+
+    // 数字またはピリオドが出続けている間、数字として解釈する
+    /// https://www.w3.org/TR/css-syntax-3/#consume-number
+    /// https://www.w3.org/TR/css-syntax-3/#consume-a-numeric-token
+    /// 例: `12.34` → 12.34
+    /// 注意: `.5` のような先頭ドット数値や指数表記 `1e3` は未対応です。
+    fn consume_numeric_token(&mut self) -> f64 {
+        let mut num = 0f64;
+        let mut floating = false;
+        let mut floating_digit = 1f64;
+
+        loop {
+            if self.pos >= self.input.len() {
+                return num;
+            }
+
+            let c = self.input[self.pos];
+
+            match c {
+                '0'..='9' => {
+                    if floating {
+                        floating_digit *= 1f64 / 10f64;
+                        num += (c.to_digit(10).unwrap() as f64) * floating_digit
+                    } else {
+                        num = num * 10.0 + (c.to_digit(10).unwrap() as f64);
+                    }
+                    self.pos += 1;
+                }
+                '.' => {
+                    floating = true;
+                    self.pos += 1;
+                }
+                _ => break,
+            }
+        }
+
+        num
+    }
+
+    // 文字、数字、ハイフン、アンダースコアが出続けている間、識別子として扱う
+    // それ以外の入力が出てきたら、今までの文字を返してメソッドを終了する
+    /// https://www.w3.org/TR/css-syntax-3/#consume-ident-like-token
+    /// https://www.w3.org/TR/css-syntax-3/#consume-name
+    /// 例: `color` や `background-color` → `"color"`, `"background-color"`
+    /// 注意: CSS の厳密な name-start / name-char 規則（非ASCII, escape など）は簡略化しています。
+    fn consume_ident_token(&mut self) -> String {
+        let mut s = String::new();
+        s.push(self.input[self.pos]);
+
+        loop {
+            self.pos += 1;
+            let c = self.input[self.pos];
+            match c {
+                'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' => {
+                    s.push(c);
+                }
+                _ => break,
+            }
+        }
+
+        s
+    }
+}
+
+impl Iterator for CssTokenizer {
+    type Item = CssToken;
+
+    /// https://www.w3.org/TR/css-syntax-3/#consume-token
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            // 0) 入力末尾ならイテレータ終了（None）。
+            if self.pos >= self.input.len() {
+                return None;
+            }
+
+            // 1) まだ pos は進めず、現在位置の1文字を見て種別を判定。
+            let c = self.input[self.pos];
+
+            // 2) 先頭文字に応じて分岐。必要なら consume_* で“塊”を読み切る。
+            let token = match c {
+                // 記号類: コロン、セミコロン、丸括弧、波括弧など
+                // CSS では宣言の区切りや関数呼び出しの括弧に使われます。
+                '(' => CssToken::OpenParenthesis,
+                ')' => CssToken::CloseParenthesis,
+                ',' => CssToken::Delim(','),
+                '.' => {
+                    // 簡易: 直後が数字でも `.5` を Number とせず Delim('.') とする。
+                    // 対応したい場合はここで先読みして consume_numeric_token を呼ぶ分岐を追加します。
+                    CssToken::Delim('.')
+                }
+                ':' => CssToken::Colon,
+                ';' => CssToken::SemiColon,
+                '{' => CssToken::OpenCurly,
+                '}' => CssToken::CloseCurly,
+                ' ' | '\n' => {
+                    // 空白・改行は“トークン化せず”読み飛ばす。
+                    self.pos += 1;
+                    continue;
+                }
+                // 文字列: ダブル/シングルクォートで囲まれたもの
+                '"' | '\'' => {
+                    let value = self.consume_string_token();
+                    CssToken::StringToken(value)
+                }
+                // 数値
+                '0'..='9' => {
+                    let t = CssToken::Number(self.consume_numeric_token());
+                    // consume_* 内で pos を進めた分、末尾の pos += 1 と釣り合うように 1 戻す（帳尻合わせ）。
+                    self.pos -= 1;
+                    t
+                }
+                // #ID or 色コード風（本実装では単純化して識別子の連結）
+                '#' => {
+                    // 簡易版: 常に `#` に続く識別子を HashToken とする。
+                    let value = self.consume_ident_token();
+                    self.pos -= 1;
+                    CssToken::HashToken(value)
+                }
+                // ハイフン始まりは識別子とみなす（負の数は扱わない前提）
+                '-' => {
+                    // 例: `--var` や `border-left` の先頭 `-`
+                    let t = CssToken::Ident(self.consume_ident_token());
+                    self.pos -= 1;
+                    t
+                }
+                '@' => {
+                    // `@media` / `@import` のような at-keyword を簡易判定。
+                    // 3文字先までが英数字のとき AtKeyword とみなし、そうでなければ単独記号扱い。
+                    // 本来は「@ の後に ident を読む」処理で十分ですが、
+                    // 短絡評価の例として3文字先までの簡易チェックを入れています。
+                    if self.input[self.pos + 1].is_ascii_alphabetic()
+                        && self.input[self.pos + 2].is_alphanumeric()
+                        && self.input[self.pos + 3].is_alphanumeric()
+                    {
+                        // skip '@'
+                        self.pos += 1;
+                        let t = CssToken::AtKeyword(self.consume_ident_token());
+                        self.pos -= 1;
+                        t
+                    } else {
+                        CssToken::Delim('@')
+                    }
+                }
+                // 識別子（プロパティ名やキーワード）
+                'a'..='z' | 'A'..='Z' | '_' => {
+                    let t = CssToken::Ident(self.consume_ident_token());
+                    self.pos -= 1;
+                    t
+                }
+                _ => {
+                    // 未対応の文字は学習用に unimplemented! で明示
+                    unimplemented!("char {} is not supported yet", c);
+                }
+            };
+
+            // 3) 1 トークン確定。読み位置を 1 進めて返す。
+            self.pos += 1;
+            // 呼び出し側は再度 next() を呼んで次トークンを取得する。
+            return Some(token);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn test_empty() {
+        // 入力が空文字のとき、最初の next() で None（トークン無し）になることを確認。
+        let style = "".to_string();
+        let mut t = CssTokenizer::new(style);
+        assert!(t.next().is_none());
+    }
+
+    #[test]
+    fn test_one_rule() {
+        // 単一ルール: p { color: red; }
+        // 期待トークン列（順に取り出せることを確認）
+        let style = "p { color: red; }".to_string();
+        let mut t = CssTokenizer::new(style);
+        let expected = [
+            CssToken::Ident("p".to_string()), // セレクタ（要素名）
+            CssToken::OpenCurly,              // '{'
+            CssToken::Ident("color".to_string()),
+            CssToken::Colon, // ':'
+            CssToken::Ident("red".to_string()),
+            CssToken::SemiColon,  // ';'
+            CssToken::CloseCurly, // '}'
+        ];
+        for e in expected {
+            assert_eq!(Some(e.clone()), t.next());
+        }
+        // 取り尽くしたら None
+        assert!(t.next().is_none());
+    }
+
+    #[test]
+    fn test_id_selector() {
+        // ID セレクタ: #id { color: red; }
+        // 簡易実装では HashToken("#id") として“#を含んだまま”読ませています。
+        let style = "#id { color: red; }".to_string();
+        let mut t = CssTokenizer::new(style);
+        let expected = [
+            CssToken::HashToken("#id".to_string()),
+            CssToken::OpenCurly,
+            CssToken::Ident("color".to_string()),
+            CssToken::Colon,
+            CssToken::Ident("red".to_string()),
+            CssToken::SemiColon,
+            CssToken::CloseCurly,
+        ];
+        for e in expected {
+            assert_eq!(Some(e.clone()), t.next());
+        }
+        assert!(t.next().is_none());
+    }
+
+    #[test]
+    fn test_class_selector() {
+        // クラスセレクタ: .class { color: red; }
+        // 現状の簡易実装では先頭 '.' を Delim('.') として返し、続く "class" を Ident として返します。
+        let style = ".class { color: red; }".to_string();
+        let mut t = CssTokenizer::new(style);
+        let expected = [
+            CssToken::Delim('.'),
+            CssToken::Ident("class".to_string()),
+            CssToken::OpenCurly,
+            CssToken::Ident("color".to_string()),
+            CssToken::Colon,
+            CssToken::Ident("red".to_string()),
+            CssToken::SemiColon,
+            CssToken::CloseCurly,
+        ];
+        for e in expected {
+            assert_eq!(Some(e.clone()), t.next());
+        }
+        assert!(t.next().is_none());
+    }
+
+    #[test]
+    fn test_multiple_rules() {
+        // 複数ルールと混在する値の検証。
+        // 入力: p { content: "Hey"; } h1 { font-size: 40; color: blue; }
+        // - StringToken("Hey") は引用符付き文字列
+        // - Number(40.0) は数値トークンとして読まれる（単位は未対応）
+        let style = "p { content: \"Hey\"; } h1 { font-size: 40; color: blue; }".to_string();
+        let mut t = CssTokenizer::new(style);
+        let expected = [
+            CssToken::Ident("p".to_string()),
+            CssToken::OpenCurly,
+            CssToken::Ident("content".to_string()),
+            CssToken::Colon,
+            CssToken::StringToken("Hey".to_string()),
+            CssToken::SemiColon,
+            CssToken::CloseCurly,
+            CssToken::Ident("h1".to_string()),
+            CssToken::OpenCurly,
+            CssToken::Ident("font-size".to_string()),
+            CssToken::Colon,
+            CssToken::Number(40.0),
+            CssToken::SemiColon,
+            CssToken::Ident("color".to_string()),
+            CssToken::Colon,
+            CssToken::Ident("blue".to_string()),
+            CssToken::SemiColon,
+            CssToken::CloseCurly,
+        ];
+        for e in expected {
+            assert_eq!(Some(e.clone()), t.next());
+        }
+        assert!(t.next().is_none());
+    }
+}

--- a/saba/saba_core/src/renderer/dom/api.rs
+++ b/saba/saba_core/src/renderer/dom/api.rs
@@ -1,0 +1,89 @@
+//! DOM のユーティリティ API（初心者向け）
+//!
+//! ここでは DOM ツリー（`Node`）をたどって、特定の要素（`ElementKind`）を探す
+//! 小さなヘルパー関数を提供します。実ブラウザで言うと、非常に限定的な
+//! `document.querySelector("tag")` のような処理のイメージです。
+//!
+//! 言語ブリッジ（TS / Python / Go）
+//! - 再帰関数で「先に子、次に兄弟」をたどる DFS（深さ優先探索）をしています。
+//! - 返り値 `Option<Rc<RefCell<Node>>>` は、“見つかったら Some(ノード)、なければ None”。
+//! - `Rc<RefCell<Node>>` は「共有 + 内部可変」なノード参照です（TS/Python/Go の参照共有に近い）。
+//!
+//! 例（概念）
+//! - ツリー: Document → html → head, body → body 配下に p, h1…
+//! - 呼び出し: `get_target_element_node(Some(document), ElementKind::Body)`
+//!   → 最初に見つかった `<body>` ノードの `Rc<RefCell<Node>>` を返します。
+
+use crate::renderer::dom::node::Element;
+use crate::renderer::dom::node::ElementKind;
+use crate::renderer::dom::node::Node;
+use crate::renderer::dom::node::NodeKind;
+use alloc::rc::Rc;
+use alloc::string::String;
+use alloc::string::ToString;
+use alloc::vec::Vec;
+use core::cell::RefCell;
+
+/// ツリーを深さ優先で探索し、最初に見つかった `element_kind` の要素ノードを返す
+///
+/// - 探索順: 「自分 → 子（first_child）→ 兄弟（next_sibling）」の順で DFS。
+/// - 一致条件: `NodeKind::Element(ElementKind == 指定)` のノードかどうか。
+/// - 返り値: 見つかれば Some(ノード参照)、なければ None。
+///
+/// 注意
+/// - ここでは比較の簡易化のため、`Element::new(kind_as_str, Vec::new())` を使って
+///   `NodeKind::Element(...)` と等価比較しています（属性は空で OK）。
+/// - 最初に見つかった 1 件だけ返す仕様です（複数取得は別の関数でベクタに集めるのが良い）。
+pub fn get_target_element_node(
+    node: Option<Rc<RefCell<Node>>>,
+    element_kind: ElementKind,
+) -> Option<Rc<RefCell<Node>>> {
+    match node {
+        Some(n) => {
+            // 1) 現在ノードが条件に一致するかをチェック
+            if n.borrow().kind()
+                == NodeKind::Element(Element::new(&element_kind.to_string(), Vec::new()))
+            {
+                return Some(n.clone()); // 見つかったので即返す
+            }
+            // 2) 異なる場合は、子 → 兄弟の順で再帰的に探索する
+            let result1 = get_target_element_node(n.borrow().first_child(), element_kind); // 子へ降りる
+            let result2 = get_target_element_node(n.borrow().next_sibling(), element_kind); // 兄弟へ進む
+            if result1.is_none() && result2.is_none() {
+                return None;
+            }
+            if result1.is_none() {
+                return result2;
+            }
+            result1
+        }
+        None => None,
+    }
+}
+
+/// DOM から <style> タグの“テキスト中身”だけを取り出すヘルパー
+///
+/// 仕様（このプロジェクト内での前提）
+/// - スタイルは `<style>ここに CSS 文字列</style>` のように、テキストノード1つで入っている想定。
+/// - `<style>` が無い、または <style> の直下がテキストでない場合は空文字を返します。
+///
+/// 例
+/// - 入力 DOM: <head><style>p { color: red; }</style></head> → "p { color: red; }"
+pub fn get_style_content(root: Rc<RefCell<Node>>) -> String {
+    // 1) ツリーから最初の <style> 要素を探す
+    let style_node = match get_target_element_node(Some(root), ElementKind::Style) {
+        Some(node) => node,
+        None => return "".to_string(), // スタイルが無ければ空文字
+    };
+    // 2) <style> の直下の最初の子がテキストノードであることを期待
+    let text_node = match style_node.borrow().first_child() {
+        Some(node) => node,
+        None => return "".to_string(),
+    };
+    // 3) テキストであればそのまま中身を返す。その他（要素など）の場合は空文字
+    let content = match &text_node.borrow().kind() {
+        NodeKind::Text(ref s) => s.clone(),
+        _ => "".to_string(),
+    };
+    content
+}

--- a/saba/saba_core/src/renderer/dom/mod.rs
+++ b/saba/saba_core/src/renderer/dom/mod.rs
@@ -1,1 +1,2 @@
+pub mod api;
 pub mod node;

--- a/saba/saba_core/src/renderer/layout/computed_style.rs
+++ b/saba/saba_core/src/renderer/layout/computed_style.rs
@@ -1,0 +1,360 @@
+use crate::error::Error;
+use crate::renderer::dom::node::ElementKind;
+use crate::renderer::dom::node::Node;
+use crate::renderer::dom::node::NodeKind;
+use alloc::format;
+use alloc::rc::Rc;
+use alloc::string::String;
+use alloc::string::ToString;
+use core::cell::RefCell;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ComputedStyle {
+    background_color: Option<Color>,
+    color: Option<Color>,
+    display: Option<DisplayType>,
+    font_size: Option<FontSize>,
+    text_decoration: Option<TextDecoration>,
+    height: Option<f64>,
+    width: Option<f64>,
+}
+
+impl ComputedStyle {
+    pub fn new() -> Self {
+        Self {
+            background_color: None,
+            color: None,
+            display: None,
+            font_size: None,
+            text_decoration: None,
+            height: None,
+            width: None,
+        }
+    }
+
+    pub fn defaulting(&mut self, node: &Rc<RefCell<Node>>, parent_style: Option<ComputedStyle>) {
+        // もし親ノードが存在し、親のCSSの値が初期値とは異なる場合、値を継承する
+        if let Some(parent_style) = parent_style {
+            if self.background_color.is_none() && parent_style.background_color() != Color::white()
+            {
+                self.background_color = Some(parent_style.background_color());
+            }
+            if self.color.is_none() && parent_style.color() != Color::black() {
+                self.color = Some(parent_style.color());
+            }
+            if self.font_size.is_none() && parent_style.font_size() != FontSize::Medium {
+                self.font_size = Some(parent_style.font_size());
+            }
+            if self.text_decoration.is_none()
+                && parent_style.text_decoration() != TextDecoration::None
+            {
+                self.text_decoration = Some(parent_style.text_decoration());
+            }
+        }
+
+        // 各プロパティに対して、初期値を設定する
+        if self.background_color.is_none() {
+            self.background_color = Some(Color::white());
+        }
+        if self.color.is_none() {
+            self.color = Some(Color::black());
+        }
+        if self.display.is_none() {
+            self.display = Some(DisplayType::default(node));
+        }
+        if self.font_size.is_none() {
+            self.font_size = Some(FontSize::default(node));
+        }
+        if self.text_decoration.is_none() {
+            self.text_decoration = Some(TextDecoration::default(node));
+        }
+        if self.height.is_none() {
+            self.height = Some(0.0);
+        }
+        if self.width.is_none() {
+            self.width = Some(0.0);
+        }
+    }
+
+    pub fn set_background_color(&mut self, color: Color) {
+        self.background_color = Some(color);
+    }
+
+    pub fn background_color(&self) -> Color {
+        self.background_color
+            .clone()
+            .expect("failed to access CSS property: background_color")
+    }
+
+    pub fn set_color(&mut self, color: Color) {
+        self.color = Some(color);
+    }
+
+    pub fn color(&self) -> Color {
+        self.color
+            .clone()
+            .expect("failed to access CSS property: color")
+    }
+
+    pub fn set_display(&mut self, display: DisplayType) {
+        self.display = Some(display);
+    }
+
+    pub fn display(&self) -> DisplayType {
+        self.display
+            .expect("failed to access CSS property: display")
+    }
+
+    pub fn font_size(&self) -> FontSize {
+        self.font_size
+            .expect("failed to access CSS property: font_size")
+    }
+
+    pub fn text_decoration(&self) -> TextDecoration {
+        self.text_decoration
+            .expect("failed to access CSS property: text_decoration")
+    }
+
+    pub fn set_height(&mut self, height: f64) {
+        self.height = Some(height);
+    }
+
+    pub fn height(&self) -> f64 {
+        self.height.expect("failed to access CSS property: height")
+    }
+
+    pub fn set_width(&mut self, width: f64) {
+        self.width = Some(width);
+    }
+
+    pub fn width(&self) -> f64 {
+        self.width.expect("failed to access CSS property: width")
+    }
+}
+
+// CSS の色（color）を表す最小構造体
+//
+// 役割（実ブラウザのどの部分？）
+// - CSS の color/background-color などで使う色を、名前（例: "red"）と 6 桁の #RRGGBB で保持します。
+// - 実装をシンプルにするため、対応色は固定のサンプルのみ。未対応は Error を返します。
+//
+// 言語ブリッジ（TS / Python / Go）
+// - `Option<String>` は “ある/ない” を型で表す（TS: string | undefined, Python: Optional[str]）。
+// - 16進 → 数値変換（code_u32）は `int('RRGGBB', 16)` のイメージ。
+#[derive(Debug, Clone, PartialEq)]
+pub struct Color {
+    name: Option<String>, // 例: Some("red")。コードから生成した場合でも逆引きで Some(...) を入れる
+    code: String,         // 例: "#ff0000"（常に # + 6桁の小文字16進）
+}
+
+impl Color {
+    // 色名から Color を作る（固定の代表色のみ対応）
+    // 例: Color::from_name("red") → Ok(Color { name: Some("red"), code: "#ff0000" })
+    pub fn from_name(name: &str) -> Result<Self, Error> {
+        let code = match name {
+            "black" => "#000000".to_string(),
+            "silver" => "#c0c0c0".to_string(),
+            "gray" => "#808080".to_string(),
+            "white" => "#ffffff".to_string(),
+            "maroon" => "#800000".to_string(),
+            "red" => "#ff0000".to_string(),
+            "purple" => "#800080".to_string(),
+            "fuchsia" => "#ff00ff".to_string(),
+            "green" => "#008000".to_string(),
+            "lime" => "#00ff00".to_string(),
+            "olive" => "#808000".to_string(),
+            "yellow" => "#ffff00".to_string(),
+            "navy" => "#000080".to_string(),
+            "blue" => "#0000ff".to_string(),
+            "teal" => "#008080".to_string(),
+            "aqua" => "#00ffff".to_string(),
+            "orange" => "#ffa500".to_string(),
+            "lightgray" => "#d3d3d3".to_string(),
+            _ => {
+                return Err(Error::UnexpectedInput(format!(
+                    "color name {:?} is not supported yet",
+                    name
+                )));
+            }
+        };
+
+        Ok(Self {
+            name: Some(name.to_string()),
+            code,
+        })
+    }
+
+    // #RRGGBB から Color を作る（6桁固定の簡易版）
+    // 例: Color::from_code("#00ff00") → Ok(Color { name: Some("lime"), code: "#00ff00" })
+    // 注意: #付き7文字のみを許可。短縮形 #0f0 や alpha #RRGGBBAA は未対応。
+    pub fn from_code(code: &str) -> Result<Self, Error> {
+        if code.chars().nth(0) != Some('#') || code.len() != 7 {
+            return Err(Error::UnexpectedInput(format!(
+                "invalid color code {}",
+                code
+            )));
+        }
+
+        let name = match code {
+            "#000000" => "black".to_string(),
+            "#c0c0c0" => "silver".to_string(),
+            "#808080" => "gray".to_string(),
+            "#ffffff" => "white".to_string(),
+            "#800000" => "maroon".to_string(),
+            "#ff0000" => "red".to_string(),
+            "#800080" => "purple".to_string(),
+            "#ff00ff" => "fuchsia".to_string(),
+            "#008000" => "green".to_string(),
+            "#00ff00" => "lime".to_string(),
+            "#808000" => "olive".to_string(),
+            "#ffff00" => "yellow".to_string(),
+            "#000080" => "navy".to_string(),
+            "#0000ff" => "blue".to_string(),
+            "#008080" => "teal".to_string(),
+            "#00ffff" => "aqua".to_string(),
+            "#ffa500" => "orange".to_string(),
+            "#d3d3d3" => "lightgray".to_string(),
+            _ => {
+                return Err(Error::UnexpectedInput(format!(
+                    "color code {:?} is not supported yet",
+                    code
+                )));
+            }
+        };
+
+        Ok(Self {
+            name: Some(name),
+            code: code.to_string(),
+        })
+    }
+
+    // 定数ショートカット（便利メソッド）: 白/黒
+    pub fn white() -> Self {
+        Self {
+            name: Some("white".to_string()),
+            code: "#ffffff".to_string(),
+        }
+    }
+
+    pub fn black() -> Self {
+        Self {
+            name: Some("black".to_string()),
+            code: "#000000".to_string(),
+        }
+    }
+
+    // #RRGGBB を 0xRRGGBB の数値（u32）に変換する
+    // 例: "#00ff00" → 0x00ff00（= 65280）
+    // 注意: unwrap() はサンプル向け（固定 6 桁を前提）。実運用ではエラーハンドリング推奨。
+    pub fn code_u32(&self) -> u32 {
+        u32::from_str_radix(self.code.trim_start_matches('#'), 16).unwrap()
+    }
+}
+
+// 文字の大きさ（font-size）の簡易列挙
+//
+// - CSS の絶対サイズ（absolute-size）に対応するサンプル：medium / x-large / xx-large。
+// - 実ブラウザは相対指定（em/rem/%）や継承、ユーザー設定など多くの要素を考慮しますが、
+//   ここでは見出しタグに応じた“わかりやすい差”だけを表現します。
+// 仕様: https://www.w3.org/TR/css-fonts-4/#absolute-size-mapping
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum FontSize {
+    Medium,
+    XLarge,
+    XXLarge,
+}
+
+impl FontSize {
+    // 要素種別に応じた既定フォントサイズを返す（学習用の最小ルール）
+    // - <h1> → XXLarge, <h2> → XLarge, その他 → Medium
+    // - これは“ブラウザのスタイルシート（UA スタイル）”の超簡易版と考えてください。
+    fn default(node: &Rc<RefCell<Node>>) -> Self {
+        match &node.borrow().kind() {
+            NodeKind::Element(element) => match element.kind() {
+                ElementKind::H1 => FontSize::XXLarge,
+                ElementKind::H2 => FontSize::XLarge,
+                _ => FontSize::Medium,
+            },
+            _ => FontSize::Medium,
+        }
+    }
+}
+
+// CSS の display プロパティ（要素の“並び方”）に対応する値
+//
+// - 最小実装として `block` / `inline` / `none` の3種類のみを扱います。
+// - 実ブラウザには他にも `inline-block` / `flex` / `grid` など多数ありますが、
+//   レイアウトの基本理解に必要なコアだけに絞っています。
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum DisplayType {
+    /// https://www.w3.org/TR/css-display-3/#valdef-display-block
+    Block,
+    /// https://www.w3.org/TR/css-display-3/#valdef-display-inline
+    Inline,
+    /// https://www.w3.org/TR/css-display-3/#valdef-display-none
+    DisplayNone,
+}
+
+impl DisplayType {
+    // 要素の“既定表示形式（UA スタイルシートの超簡易版）”を返す
+    // ルール（学習用）
+    // - Document はブロック
+    // - Element: ブロック要素なら Block、そうでなければ Inline（`is_block_element()` に依存）
+    // - Text はインライン（テキストは行内に流れる）
+    fn default(node: &Rc<RefCell<Node>>) -> Self {
+        match &node.borrow().kind() {
+            NodeKind::Document => DisplayType::Block,
+            NodeKind::Element(e) => {
+                if e.is_block_element() {
+                    DisplayType::Block
+                } else {
+                    DisplayType::Inline
+                }
+            }
+            NodeKind::Text(_) => DisplayType::Inline,
+        }
+    }
+
+    // 文字列 → DisplayType への変換
+    // 入力例: "block" / "inline" / "none"
+    // 未対応のキーワードは Error を返して早期発見（将来拡張時に追加）。
+    pub fn from_str(s: &str) -> Result<Self, Error> {
+        match s {
+            "block" => Ok(Self::Block),
+            "inline" => Ok(Self::Inline),
+            "none" => Ok(Self::DisplayNone),
+            _ => Err(Error::UnexpectedInput(format!(
+                "display {:?} is not supported yet",
+                s
+            ))),
+        }
+    }
+}
+
+// CSS の text-decoration プロパティ（下線など）に対する最小の列挙
+//
+// - 学習用に `none` と `underline` のみをサポートしています。
+// - 実ブラウザには `overline` / `line-through` / `blink`（非推奨）などもあります。
+//   必要になったらここに列挙子を追加していきます。
+// 仕様: https://w3c.github.io/csswg-drafts/css-text-decor/#text-decoration-property
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum TextDecoration {
+    None,
+    Underline,
+}
+
+impl TextDecoration {
+    // 既定の装飾（UA スタイルの超簡易版）を返す
+    // ルール（学習用）
+    // - アンカータグ <a> は下線（Underline）
+    // - それ以外は None
+    fn default(node: &Rc<RefCell<Node>>) -> Self {
+        match &node.borrow().kind() {
+            NodeKind::Element(element) => match element.kind() {
+                ElementKind::A => TextDecoration::Underline,
+                _ => TextDecoration::None,
+            },
+            _ => TextDecoration::None,
+        }
+    }
+}

--- a/saba/saba_core/src/renderer/layout/layout_object.rs
+++ b/saba/saba_core/src/renderer/layout/layout_object.rs
@@ -1,0 +1,538 @@
+use crate::alloc::string::ToString;
+use crate::constants::CHAR_HEIGHT_WITH_PADDING;
+use crate::constants::CHAR_WIDTH;
+use crate::constants::CONTENT_AREA_WIDTH;
+use crate::renderer::css::cssom::ComponentValue;
+use crate::renderer::css::cssom::Declaration;
+use crate::renderer::css::cssom::Selector;
+use crate::renderer::css::cssom::StyleSheet;
+use crate::renderer::dom::node::Node;
+use crate::renderer::dom::node::NodeKind;
+use crate::renderer::layout::computed_style::Color;
+use crate::renderer::layout::computed_style::ComputedStyle;
+use crate::renderer::layout::computed_style::DisplayType;
+use crate::renderer::layout::computed_style::FontSize;
+use alloc::rc::Rc;
+use alloc::rc::Weak;
+use alloc::vec::Vec;
+use core::cell::RefCell;
+
+/// DOM ノードからレイアウトオブジェクト（描画用ノード）を1つ生成する
+///
+/// 概要
+/// - 与えられた DOM `node` に対して、CSSOM のルールを適用（カスケード）し、
+///   既定値/継承でスタイルを補完した上で `LayoutObject` を作ります。
+/// - `display:none` の場合はオブジェクトを生成せず `None` を返します（レイアウトツリーから除外）。
+/// - 最終的な `display` に基づき、`Block`/`Inline`/`Text` などの種類を確定します。
+///
+/// 引数
+/// - `node`: 変換対象の DOM ノード（`None` のとき何もしない）
+/// - `parent_obj`: 親レイアウト（継承や接続に使う）。ルートのときは `None`。
+/// - `cssom`: スタイルシート（セレクタ照合して宣言を適用）。
+///
+/// 戻り値
+/// - `Some(Rc<RefCell<LayoutObject>>)` 生成できた場合
+/// - `None` `display:none` などで描画不要な場合
+pub fn create_layout_object(
+    node: &Option<Rc<RefCell<Node>>>,
+    parent_obj: &Option<Rc<RefCell<LayoutObject>>>,
+    cssom: &StyleSheet,
+) -> Option<Rc<RefCell<LayoutObject>>> {
+    if let Some(n) = node {
+        // 1) DOM ノードに対応する LayoutObject の“器”を作る（まだスタイル未適用）
+        // LayoutObjectを作成する
+        let layout_object = Rc::new(RefCell::new(LayoutObject::new(n.clone(), parent_obj)));
+
+        // 2) CSSOM の各ルールについて、セレクタにマッチするなら宣言を適用（カスケーディング）
+        //    - is_node_selected: セレクタとこのノード（タグ名/クラス/ID等の簡易版）を照合
+        //    - cascading_style: 指定された宣言群を style に反映（後勝ち）
+        // CSSのルールをセレクタで選択されたノードに適用する
+        for rule in &cssom.rules {
+            if layout_object.borrow().is_node_selected(&rule.selector) {
+                layout_object
+                    .borrow_mut()
+                    .cascading_style(rule.declarations.clone());
+            }
+        }
+
+        // 3) 指定が無いプロパティは既定値 or 親からの継承で補う（defaulting）
+        //    - 例: color は親から継承、display は要素種別により既定値、など
+        // CSSでスタイルが指定されていない場合、デフォルトの値または親のノードから継承した値を使用する
+        let parent_style = if let Some(parent) = parent_obj {
+            Some(parent.borrow().style())
+        } else {
+            None
+        };
+        layout_object.borrow_mut().defaulting_style(n, parent_style);
+
+        // 4) display:none ならレイアウトツリーに“存在しない”扱い → ここで除外
+        // displayプロパティがnoneの場合、ノードを作成しない
+        if layout_object.borrow().style().display() == DisplayType::DisplayNone {
+            return None;
+        }
+
+        // 5) 最終的な display に基づいて、このノードの種類（Block/Inline/Text）を確定
+        // displayプロパティの最終的な値を使用してノードの種類を決定する
+        layout_object.borrow_mut().update_kind();
+        return Some(layout_object);
+    }
+    None
+}
+
+// HTML要素は表示されるコンテンツの性質に合わせてブロック要素とインライン要素に分かれる
+// ブロック要素をBlock、インライン要素をInlineで表現
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum LayoutObjectKind {
+    Block,
+    Inline,
+    Text,
+}
+
+// 描画に必要な情報を全て持った構造体
+#[derive(Debug, Clone)]
+pub struct LayoutObject {
+    kind: LayoutObjectKind,
+    node: Rc<RefCell<Node>>,
+    first_child: Option<Rc<RefCell<LayoutObject>>>,
+    next_sibling: Option<Rc<RefCell<LayoutObject>>>,
+    parent: Weak<RefCell<LayoutObject>>,
+    style: ComputedStyle,
+    point: LayoutPoint,
+    size: LayoutSize,
+}
+
+impl PartialEq for LayoutObject {
+    fn eq(&self, other: &Self) -> bool {
+        self.kind == other.kind
+    }
+}
+
+impl LayoutObject {
+    pub fn new(node: Rc<RefCell<Node>>, parent_obj: &Option<Rc<RefCell<LayoutObject>>>) -> Self {
+        let parent = match parent_obj {
+            Some(p) => Rc::downgrade(p),
+            None => Weak::new(),
+        };
+
+        Self {
+            kind: LayoutObjectKind::Block,
+            node: node.clone(),
+            first_child: None,
+            next_sibling: None,
+            parent,
+            style: ComputedStyle::new(),
+            point: LayoutPoint::new(0, 0),
+            size: LayoutSize::new(0, 0),
+        }
+    }
+
+    /// 子のサイズをもとに、このノードのレイアウトサイズ（幅・高さ）を計算する
+    ///
+    /// ルール（学習用の簡易モデル）
+    /// - Block: 親の幅をそのまま使い、高さは“子の高さの合計”（ただしインラインが横並びの場合は注意）。
+    /// - Inline: 幅=子の幅の合計, 高さ=子の高さの合計（横並び/改行の厳密処理は省略）。
+    /// - Text: 文字数×フォント比率×等幅フォント幅で幅を見積もり、コンテンツ幅を超えたら折り返し行数で高さを算出。
+    ///
+    /// 具体例
+    /// - <div>（Block）に子が <p>(20px 高) と <h1>(24px 高) → 高さ=44px, 幅=親幅。
+    /// - <span>（Inline）に "Hi"(文字高さ16px, 幅 2×8px) と 子 <a> の幅足し込み → 幅=合計, 高さ=16px など。
+    pub fn compute_size(&mut self, parent_size: LayoutSize) {
+        let mut size = LayoutSize::new(0, 0);
+
+        match self.kind() {
+            LayoutObjectKind::Block => {
+                size.set_width(parent_size.width());
+
+                // 全ての子ノードの高さを足し合わせた結果が高さになる。
+                // ただし、インライン要素が横に並んでいる場合は注意が必要
+                let mut height = 0;
+                let mut child = self.first_child();
+                let mut previous_child_kind = LayoutObjectKind::Block;
+                while child.is_some() {
+                    let c = match child {
+                        Some(c) => c,
+                        None => panic!("first child should exist"),
+                    };
+
+                    // 簡易モデル: Block → Block は縦積み、高さを単純加算。
+                    // Inline が続く場合は横並び想定だが、ここでは単純化して
+                    // “前が Block だった/今が Block だった”ときだけ加算する制御を入れている。
+                    if previous_child_kind == LayoutObjectKind::Block
+                        || c.borrow().kind() == LayoutObjectKind::Block
+                    {
+                        height += c.borrow().size.height();
+                    }
+
+                    previous_child_kind = c.borrow().kind();
+                    child = c.borrow().next_sibling();
+                }
+                size.set_height(height);
+            }
+            LayoutObjectKind::Inline => {
+                // 全ての子ノードの高さと横幅を足し合わせた結果が現在のノードの高さと横幅とになる
+                // 注: 本来は “同じ行の最大高さ＝行の高さ” だが、学習用に単純合計としている。
+                let mut width = 0;
+                let mut height = 0;
+                let mut child = self.first_child();
+                while child.is_some() {
+                    let c = match child {
+                        Some(c) => c,
+                        None => panic!("first child should exist"),
+                    };
+
+                    width += c.borrow().size.width();
+                    height += c.borrow().size.height();
+
+                    child = c.borrow().next_sibling();
+                }
+
+                size.set_width(width);
+                size.set_height(height);
+            }
+            LayoutObjectKind::Text => {
+                if let NodeKind::Text(t) = self.node_kind() {
+                    let ratio = match self.style.font_size() {
+                        FontSize::Medium => 1,
+                        FontSize::XLarge => 2,
+                        FontSize::XXLarge => 3,
+                    };
+                    // 文字幅 = 等幅フォント幅 × フォント倍率 × 文字数
+                    let width = CHAR_WIDTH * ratio * t.len() as i64;
+                    if width > CONTENT_AREA_WIDTH {
+                        // テキストが複数行のとき
+                        size.set_width(CONTENT_AREA_WIDTH);
+                        let line_num = if width.wrapping_rem(CONTENT_AREA_WIDTH) == 0 {
+                            width.wrapping_div(CONTENT_AREA_WIDTH)
+                        } else {
+                            width.wrapping_div(CONTENT_AREA_WIDTH) + 1
+                        };
+                        // 行高 = 文字高さ(行送り込) × フォント倍率 × 行数
+                        size.set_height(CHAR_HEIGHT_WITH_PADDING * ratio * line_num);
+                    } else {
+                        // テキストが1行に収まるとき
+                        size.set_width(width);
+                        // 行高 = 文字高さ(行送り込) × フォント倍率
+                        size.set_height(CHAR_HEIGHT_WITH_PADDING * ratio);
+                    }
+                }
+            }
+        }
+
+        self.size = size;
+    }
+
+    /// 直前の兄弟や親の位置から、このノードの描画位置（左上座標）を決める
+    ///
+    /// ルール（学習用の簡易モデル）
+    /// - ブロック要素は縦に積む（Y方向に進む）。兄弟が Block でも自分が Block でも改行して下へ。
+    /// - インライン要素同士は横に並べる（X方向に進む）。行折り返しの厳密処理は省略。
+    /// - 最初の子/兄弟が無い場合は、親の `parent_point` を基準に置く。
+    ///
+    /// 引数
+    /// - `parent_point`: 親のコンテンツ開始位置（この座標から子を配置）
+    /// - `previous_sibling_kind`: 直前の兄弟の種類（Block/Inline/Text）。配置方向を決めるヒント
+    /// - `previous_sibling_point`: 直前の兄弟の配置座標（Some の時のみ利用）
+    /// - `previous_sibling_size`: 直前の兄弟のサイズ（高さ/幅の足し込みに使用）
+    pub fn compute_position(
+        &mut self,
+        parent_point: LayoutPoint,
+        previous_sibling_kind: LayoutObjectKind,
+        previous_sibling_point: Option<LayoutPoint>,
+        previous_sibling_size: Option<LayoutSize>,
+    ) {
+        let mut point = LayoutPoint::new(0, 0);
+
+        match (self.kind(), previous_sibling_kind) {
+            // もしブロック要素が兄弟ノードの場合、Y軸方向に進む
+            // 具体例: <p> の次に <h1> → h1.y = p.y + p.height / h1.x = 親の x
+            (LayoutObjectKind::Block, _) | (_, LayoutObjectKind::Block) => {
+                if let (Some(size), Some(pos)) = (previous_sibling_size, previous_sibling_point) {
+                    point.set_y(pos.y() + size.height());
+                } else {
+                    point.set_y(parent_point.y());
+                }
+                point.set_x(parent_point.x());
+            }
+            // もしインライン要素が並ぶ場合、X軸方向に進む
+            // 具体例: <span>a</span><span>b</span> → 2つ目の x = 1つ目の x + 1つ目の幅, y は同じ
+            (LayoutObjectKind::Inline, LayoutObjectKind::Inline) => {
+                if let (Some(size), Some(pos)) = (previous_sibling_size, previous_sibling_point) {
+                    point.set_x(pos.x() + size.width());
+                    point.set_y(pos.y());
+                } else {
+                    point.set_x(parent_point.x());
+                    point.set_y(parent_point.y());
+                }
+            }
+            _ => {
+                // それ以外（例えば最初の子や、前の兄弟が無い/不定のケース）は親座標に揃える
+                point.set_x(parent_point.x());
+                point.set_y(parent_point.y());
+            }
+        }
+
+        self.point = point;
+    }
+
+    //  CSSのルールをレイアウトツリーのノードに適用すべきかどうかを判断する
+    //  具体的には、与えられた `selector`（簡易: タグ/クラス/id）と、このレイアウトオブジェクトが
+    //  参照している DOM ノード（Element）の情報を突き合わせ、マッチすれば true を返す。
+    //
+    //  簡易仕様（学習用）
+    //  - TypeSelector("p")  → 要素名が "p" のときに一致
+    //  - ClassSelector("note") → 属性 `class="note"` のときに一致（複数クラスは未対応）
+    //  - IdSelector("main") → 属性 `id="main"` のときに一致
+    //  - UnknownSelector → 常に不一致
+    //  注: 現実の CSS は複合セレクタやスペース区切り（子孫/子/兄弟）など多様だが、ここでは最小限のみ。
+    pub fn is_node_selected(&self, selector: &Selector) -> bool {
+        match &self.node_kind() {
+            NodeKind::Element(e) => match selector {
+                // タグ名（タイプセレクタ）: 例) p { ... }
+                Selector::TypeSelector(type_name) => {
+                    // ElementKind → 文字列（"p" など）に直して完全一致で判定
+                    if e.kind().to_string() == *type_name {
+                        return true;
+                    }
+                    false
+                }
+                // クラスセレクタ: 例) .note { ... }
+                Selector::ClassSelector(class_name) => {
+                    // 属性列から name="class" を探し、値が完全一致するかで判定
+                    // 注意: 本実装は "class1 class2" のような複数クラスを分割しない（簡易）
+                    for attr in &e.attributes() {
+                        if attr.name() == "class" && attr.value() == *class_name {
+                            return true;
+                        }
+                    }
+                    false
+                }
+                // ID セレクタ: 例) #main { ... }
+                Selector::IdSelector(id_name) => {
+                    // 属性列から name="id" を探し、値が完全一致するかで判定
+                    for attr in &e.attributes() {
+                        if attr.name() == "id" && attr.value() == *id_name {
+                            return true;
+                        }
+                    }
+                    false
+                }
+                // 未対応（あるいは読み飛ばし対象）のセレクタは常に不一致
+                Selector::UnknownSelector => false,
+            },
+            // テキスト/ドキュメントはセレクタの対象外とする
+            _ => false,
+        }
+    }
+
+    // ノードがセレクタによって選択されている場合、そのCSSルールをノードに適用する
+    // CSSの宣言リストを引数に取り、各宣言のプロパティをノードに適用する
+    //
+    // 関数の概要
+    // - `declarations` に含まれる `property: value` を 1 件ずつこの LayoutObject の ComputedStyle に反映します。
+    // - サポート範囲（学習用）: background-color / color / display
+    // - 値の受け取り方は簡易トークンベース（ComponentValue = CssToken）。
+    //
+    // 具体例
+    // - background-color: Ident("red")         → set_background_color(#ff0000)
+    // - background-color: HashToken("#00ff00") → set_background_color(#00ff00)
+    // - color: Ident("blue")                   → set_color(#0000ff)
+    // - display: Ident("block")                → set_display(DisplayType::Block)
+    pub fn cascading_style(&mut self, declarations: Vec<Declaration>) {
+        for declaration in declarations {
+            match declaration.property.as_str() {
+                "background-color" => {
+                    // 例1) background-color: red;  → Ident("red") を色名に解釈
+                    if let ComponentValue::Ident(value) = &declaration.value {
+                        let color = match Color::from_name(&value) {
+                            Ok(color) => color,
+                            Err(_) => Color::white(),
+                        };
+                        self.style.set_background_color(color);
+                        continue;
+                    }
+
+                    // 例2) background-color: #00ff00; → HashToken("#00ff00") を #RRGGBB として解釈
+                    if let ComponentValue::HashToken(color_code) = &declaration.value {
+                        let color = match Color::from_code(&color_code) {
+                            Ok(color) => color,
+                            Err(_) => Color::white(),
+                        };
+                        self.style.set_background_color(color);
+                        continue;
+                    }
+                }
+                "color" => {
+                    // 例3) color: blue; → Ident("blue")
+                    if let ComponentValue::Ident(value) = &declaration.value {
+                        let color = match Color::from_name(&value) {
+                            Ok(color) => color,
+                            Err(_) => Color::black(),
+                        };
+                        self.style.set_color(color);
+                    }
+
+                    // 例4) color: #0000ff; → HashToken("#0000ff")
+                    if let ComponentValue::HashToken(color_code) = &declaration.value {
+                        let color = match Color::from_code(&color_code) {
+                            Ok(color) => color,
+                            Err(_) => Color::black(),
+                        };
+                        self.style.set_color(color);
+                    }
+                }
+                "display" => {
+                    // 例5) display: block; / inline; / none; → Ident("block"|"inline"|"none")
+                    if let ComponentValue::Ident(value) = declaration.value {
+                        let display_type = match DisplayType::from_str(&value) {
+                            Ok(display_type) => display_type,
+                            Err(_) => DisplayType::DisplayNone,
+                        };
+                        self.style.set_display(display_type)
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    pub fn defaulting_style(
+        &mut self,
+        node: &Rc<RefCell<Node>>,
+        parent_style: Option<ComputedStyle>,
+    ) {
+        self.style.defaulting(node, parent_style);
+    }
+
+    // カスケード、デフォルティングを経てCSSの値が最終的に決定した後、あらためてLayoutObjectのノードがブロック要素になるかインライン要素になるかを決定する
+    //
+    // 関数の概要
+    // - この時点で `self.style` には、指定（cascading）→ 既定/継承（defaulting）を通過した
+    //   “最終”の display が入っています。その値にもとづき `LayoutObjectKind` を確定します。
+    // - Document はレイアウトオブジェクト化しない前提（パニック）。Text は常に Text。
+    // - display:none はレイアウトツリーに現れないはずなので、ここに来たらロジック不整合としてパニック。
+    //
+    // 具体例
+    // - <p style="display:block"> ... → kind=Block
+    // - <span style="display:inline"> ... → kind=Inline
+    // - テキストノード → kind=Text
+    pub fn update_kind(&mut self) {
+        match self.node_kind() {
+            NodeKind::Document => panic!("should not create a layout object for a Document node"),
+            NodeKind::Element(_) => {
+                // 1) 最終的な display を取得
+                let display = self.style.display();
+                match display {
+                    // 2) display の種類に応じて LayoutObjectKind を確定
+                    DisplayType::Block => self.kind = LayoutObjectKind::Block,
+                    DisplayType::Inline => self.kind = LayoutObjectKind::Inline,
+                    DisplayType::DisplayNone => {
+                        panic!("should not create a layout object for display:none")
+                    }
+                }
+            }
+            // テキストノードは常に Text（行内に流れる）
+            NodeKind::Text(_) => self.kind = LayoutObjectKind::Text,
+        }
+    }
+
+    // LayoutObjectのフィールドは全てプライベートなので、変更・取得のメソッドを追加する
+    pub fn kind(&self) -> LayoutObjectKind {
+        self.kind
+    }
+
+    pub fn node_kind(&self) -> NodeKind {
+        self.node.borrow().kind().clone()
+    }
+
+    pub fn set_first_child(&mut self, first_child: Option<Rc<RefCell<LayoutObject>>>) {
+        self.first_child = first_child;
+    }
+
+    pub fn first_child(&self) -> Option<Rc<RefCell<LayoutObject>>> {
+        self.first_child.as_ref().cloned()
+    }
+
+    pub fn set_next_sibling(&mut self, next_sibling: Option<Rc<RefCell<LayoutObject>>>) {
+        self.next_sibling = next_sibling;
+    }
+
+    pub fn next_sibling(&self) -> Option<Rc<RefCell<LayoutObject>>> {
+        self.next_sibling.as_ref().cloned()
+    }
+
+    pub fn parent(&self) -> Weak<RefCell<Self>> {
+        self.parent.clone()
+    }
+
+    pub fn style(&self) -> ComputedStyle {
+        self.style.clone()
+    }
+
+    pub fn point(&self) -> LayoutPoint {
+        self.point
+    }
+
+    pub fn size(&self) -> LayoutSize {
+        self.size
+    }
+}
+
+// LayoutObjectの位置を表すデータ構造
+// レイアウトツリー構築の際に、各要素の描画される位置を計算する
+#[derive(Debug, Clone, PartialEq, Copy)]
+pub struct LayoutPoint {
+    x: i64,
+    y: i64,
+}
+
+impl LayoutPoint {
+    pub fn new(x: i64, y: i64) -> Self {
+        Self { x, y }
+    }
+
+    pub fn x(&self) -> i64 {
+        self.x
+    }
+
+    pub fn y(&self) -> i64 {
+        self.y
+    }
+
+    pub fn set_x(&mut self, x: i64) {
+        self.x = x;
+    }
+
+    pub fn set_y(&mut self, y: i64) {
+        self.y = y;
+    }
+}
+
+// LayoutObjectのサイズを表すデータ構造
+// レイアウトツリー構築の際に、各要素のサイズを計算する
+#[derive(Debug, Clone, PartialEq, Copy)]
+pub struct LayoutSize {
+    width: i64,
+    height: i64,
+}
+
+impl LayoutSize {
+    pub fn new(width: i64, height: i64) -> Self {
+        Self { width, height }
+    }
+
+    pub fn width(&self) -> i64 {
+        self.width
+    }
+
+    pub fn height(&self) -> i64 {
+        self.height
+    }
+
+    pub fn set_width(&mut self, width: i64) {
+        self.width = width;
+    }
+
+    pub fn set_height(&mut self, height: i64) {
+        self.height = height;
+    }
+}

--- a/saba/saba_core/src/renderer/layout/layout_view.rs
+++ b/saba/saba_core/src/renderer/layout/layout_view.rs
@@ -1,0 +1,441 @@
+//! レイアウトビュー（LayoutView）— DOM/CSSOM からレイアウトツリーを作り、サイズと位置を決める
+//!
+//! 役割
+//! - DOM（描画対象の要素）をレイアウトオブジェクトへ変換し、CSS（CSSOM）を基に
+//!   “サイズ（compute_size）”と“位置（compute_position）”を再帰的に計算します。
+//! - 実ブラウザの「レイアウトステージ」の超簡易版です。display:none の除外、
+//!   block/inline とテキストの基本的な並びを扱います。
+//!
+//! 全体フロー
+//! 1) <body> の直下から、描画対象のみのレイアウトツリーを構築（build_layout_tree）
+//! 2) 各ノードのサイズを自前ルールで算出（calculate_node_size → compute_size）
+//! 3) 各ノードの位置（左上座標）を決定（calculate_node_position → compute_position）
+//!
+//! 制約（学習用の簡易化）
+//! - 行折り返しや margin/padding/border、line-height 等の厳密処理は省略
+//! - display は block/inline/none のみ
+//! - テキストは等幅フォントで粗い見積り
+use crate::constants::CONTENT_AREA_WIDTH;
+use crate::renderer::css::cssom::StyleSheet;
+use crate::renderer::dom::api::get_target_element_node;
+use crate::renderer::dom::node::ElementKind;
+use crate::renderer::dom::node::Node;
+use crate::renderer::layout::layout_object::create_layout_object;
+use crate::renderer::layout::layout_object::LayoutObject;
+use crate::renderer::layout::layout_object::LayoutObjectKind;
+use crate::renderer::layout::layout_object::LayoutPoint;
+use crate::renderer::layout::layout_object::LayoutSize;
+use alloc::rc::Rc;
+use core::cell::RefCell;
+
+// DOM ツリー → レイアウトツリー（描画対象のみ）を組み立てる
+//
+// ざっくりの流れ（実ブラウザの“レイアウトツリービルド”に相当）
+// 1) 現在の DOM ノードから `create_layout_object` を試みる
+//    - CSS が `display: none` なら LayoutObject は「作らない」→ 兄弟へスキップ
+// 2) 作れたら、それを親として子/兄弟について同様に再帰処理
+// 3) 子にも兄弟にも `display: none` があり得るので、作れるまで“次の兄弟へ”進み続ける
+//
+// 重要ポイント
+// - レイアウトツリーは「描画される要素だけ」を持つ（`display:none` はツリーから除外）
+// - “DOM の形”と“レイアウトツリーの形”は一致しないことがある（不可視要素の除去など）
+fn build_layout_tree(
+    node: &Option<Rc<RefCell<Node>>>,
+    parent_obj: &Option<Rc<RefCell<LayoutObject>>>,
+    cssom: &StyleSheet,
+) -> Option<Rc<RefCell<LayoutObject>>> {
+    // 1) まず現在の DOM ノードから LayoutObject を作成してみる
+    //    - `create_layout_object` は CSSOM を参照して `display:none` なら None を返す
+    // `create_layout_object`関数によって、ノードとなるLayoutObjectの作成を試みる。
+    // CSSによって"display:none"が指定されていた場合、ノードは作成されない
+    let mut target_node = node.clone();
+    let mut layout_object = create_layout_object(node, parent_obj, cssom);
+    // 2) 作れなかった（= display:none 等）場合、兄弟へ進み“作れるまで”繰り返し
+    // もしノードが作成されなかった場合、DOMノードの兄弟ノードを使用してLayoutObjectの
+    // 作成を試みる。LayoutObjectが作成されるまで、兄弟ノードを辿り続ける
+    while layout_object.is_none() {
+        if let Some(n) = target_node {
+            target_node = n.borrow().next_sibling().clone();
+            layout_object = create_layout_object(&target_node, parent_obj, cssom);
+        } else {
+            // 兄弟ノードが無ければ、これ以上作る要素は無い → ここまでで終了
+            // もし兄弟ノードがない場合、処理するべきDOMツリーは終了したので、今まで
+            // 作成したレイアウトツリーを返す
+            return layout_object;
+        }
+    }
+
+    if let Some(n) = target_node {
+        let original_first_child = n.borrow().first_child();
+        let original_next_sibling = n.borrow().next_sibling();
+        // 3) 子と兄弟について再帰的にレイアウトツリーを作る
+        //    - 子の親は“今作った LayoutObject”
+        //    - 兄弟は“同じ親”を共有するので、ここでは親 None → 上の呼び出し側が適切に接続する
+        // もし子ノードに"display:node"が指定されていた場合、LayoutObjectは作成され
+        // ないため、子ノードの兄弟ノードを使用してLayoutObjectの作成を試みる。
+        // LayoutObjectが作成されるか、辿るべき兄弟ノードがなくなるまで処理を繰り返す
+        let mut first_child = build_layout_tree(&original_first_child, &layout_object, cssom);
+        let mut next_sibling = build_layout_tree(&original_next_sibling, &None, cssom);
+
+        // 4) 子が `display:none` で作られなかった場合 → 子の“兄弟”を順に試す
+        //    LayoutObject が作れるまで、または辿る兄弟が尽きるまで進める
+        if first_child.is_none() && original_first_child.is_some() {
+            let mut original_dom_node = original_first_child
+                .expect("first child should exist")
+                .borrow()
+                .next_sibling();
+
+            loop {
+                first_child = build_layout_tree(&original_dom_node, &layout_object, cssom);
+
+                if first_child.is_none() && original_dom_node.is_some() {
+                    original_dom_node = original_dom_node
+                        .expect("next sibling should exist")
+                        .borrow()
+                        .next_sibling();
+                    continue;
+                }
+
+                break;
+            }
+        }
+
+        // 5) 兄弟が `display:none` で作られなかった場合 → 兄弟の“次の兄弟”を順に試す
+        //    LayoutObject が作れるまで、または辿る兄弟が尽きるまで進める
+        // もし兄弟ノードに"display:node"が指定されていた場合、LayoutObjectは作成され
+        // ないため、兄弟ノードの兄弟ノードを使用してLayoutObjectの作成を試みる。
+        // LayoutObjectが作成されるか、辿るべき兄弟ノードがなくなるまで処理を繰り返す
+        if next_sibling.is_none() && n.borrow().next_sibling().is_some() {
+            let mut original_dom_node = original_next_sibling
+                .expect("first child should exist")
+                .borrow()
+                .next_sibling();
+
+            loop {
+                next_sibling = build_layout_tree(&original_dom_node, &None, cssom);
+
+                if next_sibling.is_none() && original_dom_node.is_some() {
+                    original_dom_node = original_dom_node
+                        .expect("next sibling should exist")
+                        .borrow()
+                        .next_sibling();
+                    continue;
+                }
+
+                break;
+            }
+        }
+
+        // 6) ここまでで“現在ノードの LayoutObject”は存在している前提
+        let obj = match layout_object {
+            Some(ref obj) => obj,
+            None => panic!("render object should exist here"),
+        };
+        // 7) レイアウトツリーの接続を行う（子/兄弟）
+        obj.borrow_mut().set_first_child(first_child);
+        obj.borrow_mut().set_next_sibling(next_sibling);
+    }
+
+    layout_object
+}
+
+#[derive(Debug, Clone)]
+pub struct LayoutView {
+    root: Option<Rc<RefCell<LayoutObject>>>,
+}
+
+impl LayoutView {
+    /// DOM と CSSOM からレイアウトツリーを構築し、サイズ・位置を確定する
+    ///
+    /// 手順
+    /// - <body> のノードを起点に、`display:none` を除外したレイアウトツリーを作る（build_layout_tree）
+    /// - その後、update_layout でサイズ → 位置の順に確定
+    pub fn new(root: Rc<RefCell<Node>>, cssom: &StyleSheet) -> Self {
+        // レイアウトツリーは描画される要素だけを持つツリーなので、<body>タグを取得し、その子要素以下をレイアウトツリーのノードに変換する。
+        let body_root = get_target_element_node(Some(root), ElementKind::Body);
+
+        let mut tree = Self {
+            root: build_layout_tree(&body_root, &None, cssom),
+        };
+
+        tree.update_layout();
+
+        tree
+    }
+
+    // レイアウトツリーのノードの位置を再起的に計算する関数
+    // 第1引数が計算するターゲットとなるノード、第2引数が親ノードの位置、第3引数は自分より前の兄弟ノードの種類、第4引数は自分より前の兄弟ノードの位置、第5引数は自分より前の兄弟ノードのサイズ
+    //
+    // 概要
+    // - Block は縦方向（Y）へ、Inline は横方向（X）へ配置を進める簡易ルール。
+    // - 子→兄弟の順で深さ優先に進み、各ノードは self.compute_position で座標を確定します。
+    fn calculate_node_position(
+        node: &Option<Rc<RefCell<LayoutObject>>>,
+        parent_point: LayoutPoint,
+        previous_sibling_kind: LayoutObjectKind,
+        previous_sibling_point: Option<LayoutPoint>,
+        previous_sibling_size: Option<LayoutSize>,
+    ) {
+        if let Some(n) = node {
+            n.borrow_mut().compute_position(
+                parent_point,
+                previous_sibling_kind,
+                previous_sibling_point,
+                previous_sibling_size,
+            );
+
+            // ノード（node）の子ノードの位置を計算をする
+            let first_child = n.borrow().first_child();
+            Self::calculate_node_position(
+                &first_child,
+                n.borrow().point(),
+                LayoutObjectKind::Block,
+                None,
+                None,
+            );
+
+            // ノード（node）の兄弟ノードの位置を計算する
+            let next_sibling = n.borrow().next_sibling();
+            Self::calculate_node_position(
+                &next_sibling,
+                parent_point,
+                n.borrow().kind(),
+                Some(n.borrow().point()),
+                Some(n.borrow().size()),
+            );
+        }
+    }
+
+    // レイアウトツリーの各ノードのサイズを再起的に計算する関数
+    // 第一引数がターゲットとなるノード、第二引数は親ノードのサイズ
+    //
+    // 概要
+    // - Block の幅は“先に”親幅で確定し、高さは子のサイズ確定後に集計。
+    // - Inline/Text は子（テキスト）のサイズに依存するため、子の計算後に自分を計算。
+    fn calculate_node_size(node: &Option<Rc<RefCell<LayoutObject>>>, parent_size: LayoutSize) {
+        if let Some(n) = node {
+            // ノードがブロック要素の場合、子ノードのレイアウトを計算する前に横幅を決める
+            if n.borrow().kind() == LayoutObjectKind::Block {
+                n.borrow_mut().compute_size(parent_size);
+            }
+
+            let first_child = n.borrow().first_child();
+            Self::calculate_node_size(&first_child, n.borrow().size());
+
+            let next_sibling = n.borrow().next_sibling();
+            Self::calculate_node_size(&next_sibling, parent_size);
+
+            // 子ノードのサイズが決まった後にサイズを計算する。
+            // ブロック要素のとき、高さは子ノードの高さに依存する
+            // インライン要素のとき、高さも横幅も子ノードに依存する
+            n.borrow_mut().compute_size(parent_size);
+        }
+    }
+
+    /// レイアウトの再計算（サイズ→位置の順）
+    ///
+    /// - まずコンテンツ領域幅（CONTENT_AREA_WIDTH）を親幅に見立ててサイズ計算
+    /// - 次に (0,0) を起点に座標を割り当てていきます
+    fn update_layout(&mut self) {
+        Self::calculate_node_size(&self.root, LayoutSize::new(CONTENT_AREA_WIDTH, 0));
+
+        Self::calculate_node_position(
+            &self.root,
+            LayoutPoint::new(0, 0),
+            LayoutObjectKind::Block,
+            None,
+            None,
+        );
+    }
+
+    /// レイアウトツリーのルート（描画される最上位の LayoutObject）を返す
+    pub fn root(&self) -> Option<Rc<RefCell<LayoutObject>>> {
+        self.root.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // この tests モジュールでは、レイアウトビューを構築する“最小の足場”を用意します。
+    use super::*;
+    use crate::alloc::string::ToString;
+    use crate::renderer::css::cssom::CssParser;
+    use crate::renderer::css::token::CssTokenizer;
+    use crate::renderer::dom::api::get_style_content;
+    use crate::renderer::dom::node::Element;
+    use crate::renderer::dom::node::NodeKind;
+    use crate::renderer::html::parser::HtmlParser;
+    use crate::renderer::html::token::HtmlTokenizer;
+    use alloc::string::String;
+    use alloc::vec::Vec;
+
+    // テスト用のレイアウトビューを作るユーティリティ
+    //
+    // 手順
+    // 1) HTML 文字列 → HtmlTokenizer → HtmlParser で DOM を構築
+    // 2) DOM から <style> の中身だけを取り出し（get_style_content）、CSS をトークナイズ/パースして CSSOM を構築
+    // 3) DOM + CSSOM から LayoutView を生成（レイアウトツリーを作り、サイズ・位置を確定）
+    fn create_layout_view(html: String) -> LayoutView {
+        // 1) HTML → DOM
+        let t = HtmlTokenizer::new(html);
+        let window = HtmlParser::new(t).construct_tree();
+        let dom = window.borrow().document();
+
+        // 2) DOM 内の <style> から CSS 文字列を抽出→ CSSOM へ
+        let style = get_style_content(dom.clone());
+        let css_tokenizer = CssTokenizer::new(style);
+        let cssom = CssParser::new(css_tokenizer).parse_stylesheet();
+
+        // 3) DOM + CSSOM → LayoutView（以降のテストはこの戻り値を使って検証していく）
+        LayoutView::new(dom, &cssom)
+    }
+
+    #[test]
+    fn test_empty() {
+        // 入力: 空HTML → <body> も無いので描画対象が無い
+        let layout_view = create_layout_view("".to_string());
+        // 期待: レイアウトツリーのルートは None（何も描画しない）
+        assert_eq!(None, layout_view.root());
+    }
+
+    #[test]
+    fn test_body() {
+        // 入力: <html><head></head><body></body></html>
+        // 期待: ルートは <body> の LayoutObject（Block）
+        let html = "<html><head></head><body></body></html>".to_string();
+        let layout_view = create_layout_view(html);
+
+        let root = layout_view.root();
+        assert!(root.is_some());
+        // <body> は既定で display:block → Block になる
+        assert_eq!(
+            LayoutObjectKind::Block,
+            root.clone().expect("root should exist").borrow().kind()
+        );
+        // 参照している DOM ノードは <body>
+        assert_eq!(
+            NodeKind::Element(Element::new("body", Vec::new())),
+            root.clone()
+                .expect("root should exist")
+                .borrow()
+                .node_kind()
+        );
+    }
+
+    #[test]
+    fn test_text() {
+        // 入力: <html><head></head><body>text</body></html>
+        // 期待: ルートは <body>（Block）で、その最初の子がテキストノード "text"
+        let html = "<html><head></head><body>text</body></html>".to_string();
+        let layout_view = create_layout_view(html);
+
+        let root = layout_view.root();
+        assert!(root.is_some());
+        // <body> は Block
+        assert_eq!(
+            LayoutObjectKind::Block,
+            root.clone().expect("root should exist").borrow().kind()
+        );
+        // DOM 参照は <body>
+        assert_eq!(
+            NodeKind::Element(Element::new("body", Vec::new())),
+            root.clone()
+                .expect("root should exist")
+                .borrow()
+                .node_kind()
+        );
+
+        // 子はテキストノード（LayoutObjectKind::Text）で、内容は "text"
+        let text = root.expect("root should exist").borrow().first_child();
+        assert!(text.is_some());
+        assert_eq!(
+            LayoutObjectKind::Text,
+            text.clone()
+                .expect("text node should exist")
+                .borrow()
+                .kind()
+        );
+        assert_eq!(
+            NodeKind::Text("text".to_string()),
+            text.clone()
+                .expect("text node should exist")
+                .borrow()
+                .node_kind()
+        );
+    }
+
+    #[test]
+    fn test_display_none() {
+        // 入力: body に display:none を当てる
+        // 期待: <body> 自体がレイアウトツリーから除外されるため、ルートは None
+        let html = "<html><head><style>body{display:none;}</style></head><body>text</body></html>"
+            .to_string();
+        let layout_view = create_layout_view(html);
+
+        assert_eq!(None, layout_view.root());
+    }
+
+    #[test]
+    fn test_hidden_class() {
+        // 入力: .hidden { display:none } を定義し、隠す対象を混ぜる
+        // - <a class="hidden">link1</a> → インライン要素だが display:none で除外
+        // - <p></p>                         → 表示対象（Block）
+        // - <p class="hidden"><a>link2</a></p> → <p> ごと非表示（中の <a> も消える）
+        // 期待: レイアウトツリーの <body> の最初の子は “空の <p>” で、兄弟は存在しない
+        let html = r#"<html>
+<head>
+<style>
+  .hidden {
+    display: none;
+  }
+</style>
+</head>
+<body>
+  <a class="hidden">link1</a>
+  <p></p>
+  <p class="hidden"><a>link2</a></p>
+</body>
+</html>"#
+            .to_string();
+        let layout_view = create_layout_view(html);
+
+        let root = layout_view.root();
+        assert!(root.is_some());
+        assert_eq!(
+            LayoutObjectKind::Block,
+            root.clone().expect("root should exist").borrow().kind()
+        );
+        assert_eq!(
+            NodeKind::Element(Element::new("body", Vec::new())),
+            root.clone()
+                .expect("root should exist")
+                .borrow()
+                .node_kind()
+        );
+
+        // body の最初の子は表示対象の <p>（Block）
+        let p = root.expect("root should exist").borrow().first_child();
+        assert!(p.is_some());
+        assert_eq!(
+            LayoutObjectKind::Block,
+            p.clone().expect("p node should exist").borrow().kind()
+        );
+        assert_eq!(
+            NodeKind::Element(Element::new("p", Vec::new())),
+            p.clone().expect("p node should exist").borrow().node_kind()
+        );
+
+        // その <p> は空（子なし）で、また 2 つ目の <p class="hidden"> は display:none のため兄弟も存在しない
+        assert!(p
+            .clone()
+            .expect("p node should exist")
+            .borrow()
+            .first_child()
+            .is_none());
+        assert!(p
+            .expect("p node should exist")
+            .borrow()
+            .next_sibling()
+            .is_none());
+    }
+}

--- a/saba/saba_core/src/renderer/layout/mod.rs
+++ b/saba/saba_core/src/renderer/layout/mod.rs
@@ -1,0 +1,3 @@
+pub mod computed_style;
+pub mod layout_object;
+pub mod layout_view;

--- a/saba/saba_core/src/renderer/mod.rs
+++ b/saba/saba_core/src/renderer/mod.rs
@@ -1,4 +1,5 @@
 pub mod css;
 pub mod dom;
 pub mod html;
+pub mod layout;
 pub mod page;

--- a/saba/saba_core/src/renderer/mod.rs
+++ b/saba/saba_core/src/renderer/mod.rs
@@ -1,3 +1,4 @@
+pub mod css;
 pub mod dom;
 pub mod html;
 pub mod page;

--- a/saba/saba_core/src/renderer/page.rs
+++ b/saba/saba_core/src/renderer/page.rs
@@ -3,38 +3,58 @@
 //! 役割（実ブラウザでの位置づけ）
 //! - `Browser` が複数のページを管理し、その1枚が `Page` です。
 //! - ネットワーク層から受け取った HTTP レスポンス本文（HTML 文字列）を、
-//!   トークナイズ→パース（ツリービルド）して DOM（`Window`/`Document`）にします。
-//! - 本実装では描画の代わりに、デバッグ用のテキストに変換して返します。
+//!   トークナイズ→パース（ツリービルド）して DOM（`Window`/`Document`）にし、
+//!   さらに <style> から CSSOM を作り、レイアウト（ツリー構築→サイズ→位置）まで進めます。
+//! - 最後に描画命令（DisplayItem）を得て、描画バックエンドに渡せる状態にします。
 //!
 //! 言語ブリッジ（TS / Python / Go）
 //! - `Rc<RefCell<T>>`/`Weak<T>` は「共有 + 内部可変 / 循環参照回避」。
-//! - `receive_response` は“ページがネットワーク応答を受け取り、DOMを更新する”入口メソッド。
+//! - `receive_response` は“ページがネットワーク応答を受け取り、DOM/CSSOM→レイアウト→描画命令”へ進める入口メソッド。
 //! - `create_frame` は“タブに表示するフレーム（Window）を作る”という意味合いです。
-
-use crate::alloc::string::ToString;
+//! - `set_layout_view` は DOM/CSSOM からレイアウトツリーを作るステップ。
+//! - `paint_tree` はレイアウトツリーから DisplayItem（矩形・テキストなど）を収集します。
+//!
+//! 具体例（最小の流れ）
+//! 1) HTML: `<html><head><style>p{color:red}</style></head><body><p>Hi</p></body></html>`
+//! 2) DOM:  Document → html → head/style, body/p/text("Hi")
+//! 3) CSSOM: style から `p { color: red }`
+//! 4) Layout: body をルートにレイアウトツリー構築 → サイズ/位置計算
+//! 5) Paint: [Rect(..pの背景..), Text("Hi", ..座標..)] のような DisplayItem 列が得られる
 use crate::browser::Browser;
+use crate::display_item::DisplayItem;
 use crate::http::HttpResponse;
+use crate::renderer::css::cssom::CssParser;
+use crate::renderer::css::cssom::StyleSheet;
+use crate::renderer::css::token::CssTokenizer;
+use crate::renderer::dom::api::get_style_content;
 use crate::renderer::dom::node::Window;
 use crate::renderer::html::parser::HtmlParser;
 use crate::renderer::html::token::HtmlTokenizer;
-use crate::utils::convert_dom_to_string;
+use crate::renderer::layout::layout_view::LayoutView;
 use alloc::rc::Rc;
 use alloc::rc::Weak;
 use alloc::string::String;
+use alloc::vec::Vec;
 use core::cell::RefCell;
 
 #[derive(Debug, Clone)]
 pub struct Page {
     browser: Weak<RefCell<Browser>>,
     frame: Option<Rc<RefCell<Window>>>,
+    style: Option<StyleSheet>,
+    layout_view: Option<LayoutView>,
+    display_items: Vec<DisplayItem>,
 }
 
 impl Page {
-    // 新しい空のページを作成。まだブラウザやフレーム（Window）は紐づけられていません。
+    // 新しい空のページを作成。まだブラウザやフレーム（Window）、CSS/レイアウトは未設定。
     pub fn new() -> Self {
         Self {
             browser: Weak::new(),
             frame: None,
+            style: None,
+            layout_view: None,
+            display_items: Vec::new(),
         }
     }
 
@@ -42,29 +62,60 @@ impl Page {
     pub fn set_browser(&mut self, browser: Weak<RefCell<Browser>>) {
         self.browser = browser;
     }
-    // ネットワーク応答（HTTP）を受け取り、DOM を構築し、デバッグ文字列を返す。
-    // 実ブラウザではここから レンダリングツリー更新 → レイアウト → ペイント に進みますが、
-    // 本書の最小実装では "DOMをテキスト化して返す" までとします。
-    pub fn receive_response(&mut self, response: HttpResponse) -> String {
-        // 1) レスポンスの本文（HTML）からフレーム(Window)を作る
+
+    // ネットワーク応答（HTMLを含む）を受け取り、DOM/CSSOM→レイアウト→描画命令まで進める
+    // フロー: create_frame(HTML→DOM/CSSOM) → set_layout_view(DOM+CSSOM→Layout) → paint_tree(Layout→DisplayItem)
+    pub fn receive_response(&mut self, response: HttpResponse) {
         self.create_frame(response.body());
-
-        // 2) デバッグ用に DOM ツリーを文字列として返す
-        if let Some(frame) = &self.frame {
-            let dom = frame.borrow().document().clone();
-            let debug = convert_dom_to_string(&Some(dom));
-            return debug;
-        }
-
-        "".to_string()
+        self.set_layout_view();
+        self.paint_tree();
     }
 
-    // HTML 文字列からトークナイザ/パーサを組み合わせて Window（DOMツリー）を構築する。
-    // - HtmlTokenizer: 文字列 → トークン列（<tag>, </tag>, Char, Eof）
-    // - HtmlParser: トークン列 → DOMツリー（Window/Document/Element/Text）
+    // HTML 文字列から DOM（Window/Document）と CSSOM（StyleSheet）を作る
     fn create_frame(&mut self, html: String) {
         let html_tokenizer = HtmlTokenizer::new(html);
         let frame = HtmlParser::new(html_tokenizer).construct_tree();
+        let dom = frame.borrow().document();
+
+        let style = get_style_content(dom);
+        let css_tokenizer = CssTokenizer::new(style);
+        let cssom = CssParser::new(css_tokenizer).parse_stylesheet();
+
         self.frame = Some(frame);
+        self.style = Some(cssom);
+    }
+
+    // DOM + CSSOM から LayoutView（レイアウトツリー）を作る
+    fn set_layout_view(&mut self) {
+        let dom = match &self.frame {
+            Some(frame) => frame.borrow().document(),
+            None => return,
+        };
+
+        let style = match self.style.clone() {
+            Some(style) => style,
+            None => return,
+        };
+
+        let layout_view = LayoutView::new(dom, &style);
+
+        self.layout_view = Some(layout_view);
+    }
+
+    // レイアウトツリーから DisplayItem を収集（描画命令列）
+    fn paint_tree(&mut self) {
+        if let Some(layout_view) = &self.layout_view {
+            self.display_items = layout_view.paint();
+        }
+    }
+
+    // 収集済みの DisplayItem（矩形・テキストなど）を返す
+    pub fn display_items(&self) -> Vec<DisplayItem> {
+        self.display_items.clone()
+    }
+
+    // DisplayItem のバッファをクリアする（再描画前の初期化などに利用）
+    pub fn clear_display_items(&mut self) {
+        self.display_items = Vec::new();
     }
 }


### PR DESCRIPTION
## コレナニ
ブラウザにCSSを適用するために、CSS構文のトークナイズとその字句解析を行うロジックを実装するPRになります

このロジックを実装することで
```css
p {
    color: 'red';
}
```

上記のようなCSS構文を理解し、CSSを適用できるようになります。